### PR TITLE
Use multi-stage Docker build. Compile contracts into image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,17 @@
-FROM golang:1.16.4-alpine3.13
+FROM golang:1.16.4-alpine AS builder
 WORKDIR /firefly
 ADD . .
-RUN apk add make gcc build-base
+RUN apk add make gcc build-base nodejs npm python3
 RUN make
+WORKDIR /firefly/solidity_firefly
+RUN npm install
+RUN npm config set user 0
+RUN npx truffle compile
 
+FROM alpine:latest  
+WORKDIR /firefly
+COPY --from=builder /firefly/firefly ./firefly
+COPY --from=builder /firefly/solidity_firefly/build/contracts ./contracts
+COPY --from=builder /firefly/db ./db
+RUN ln -s /firefly/firefly /usr/bin/firefly
 ENTRYPOINT [ "firefly" ]


### PR DESCRIPTION
This change significantly reduces the size of the published Docker container, down to ~30MB from ~950MB. It also includes compiled solidity contracts in the image which can be installed if needed.