### PR TITLE
Serve frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ firefly
 coverage.txt
 **/debug.test
 .DS_Store
+frontend

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,29 @@
-FROM golang:1.16.4-alpine AS builder
+FROM golang:1.16-alpine3.13 AS firefly-builder
 WORKDIR /firefly
 ADD . .
-RUN apk add make gcc build-base nodejs npm python3
+RUN apk add make gcc build-base
 RUN make
 WORKDIR /firefly/solidity_firefly
+
+FROM node:14-alpine3.11 AS solidity-builder
+WORKDIR /firefly/solidity_firefly
+ADD solidity_firefly .
 RUN npm install
 RUN npm config set user 0
 RUN npx truffle compile
 
+FROM node:14-alpine3.11 AS firefly-ui-builder
+RUN apk add git
+RUN git clone https://github.com/kaleido-io/firefly-ui.git
+WORKDIR /firefly-ui
+RUN npm install
+RUN PUBLIC_URL="/ui" npm run build
+
 FROM alpine:latest  
 WORKDIR /firefly
-COPY --from=builder /firefly/firefly ./firefly
-COPY --from=builder /firefly/solidity_firefly/build/contracts ./contracts
-COPY --from=builder /firefly/db ./db
+COPY --from=firefly-builder /firefly/firefly ./firefly
+COPY --from=firefly-builder /firefly/db ./db
+COPY --from=solidity-builder /firefly/solidity_firefly/build/contracts ./contracts
+COPY --from=firefly-ui-builder /firefly-ui/build ./frontend
 RUN ln -s /firefly/firefly /usr/bin/firefly
 ENTRYPOINT [ "firefly" ]

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -31,13 +31,15 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/gorilla/mux"
 	"github.com/kaleido-io/firefly/internal/config"
-	"github.com/kaleido-io/firefly/pkg/database"
-	"github.com/kaleido-io/firefly/pkg/fftypes"
 	"github.com/kaleido-io/firefly/internal/i18n"
 	"github.com/kaleido-io/firefly/internal/log"
 	"github.com/kaleido-io/firefly/internal/oapispec"
 	"github.com/kaleido-io/firefly/internal/orchestrator"
+	"github.com/kaleido-io/firefly/pkg/database"
+	"github.com/kaleido-io/firefly/pkg/fftypes"
 )
+
+const uiUrlPrefix = "/ui"
 
 var ffcodeExtractor = regexp.MustCompile(`^(FF\d+):`)
 
@@ -292,6 +294,13 @@ func createMuxRouter(o orchestrator.Orchestrator) *mux.Router {
 	}
 	r.HandleFunc(`/api/swagger{ext:\.yaml|\.json|}`, apiWrapper(swaggerHandler))
 	r.HandleFunc(`/api`, apiWrapper(swaggerUIHandler))
+
+	uiPath := config.GetString(config.UIPath)
+	if uiPath != "" {
+		uiHandler := UIHandler{staticPath: uiPath, indexPath: "index.html", urlPrefix: uiUrlPrefix}
+		r.PathPrefix(uiUrlPrefix).Handler(uiHandler)
+	}
+
 	r.NotFoundHandler = apiWrapper(notFoundHandler)
 	return r
 }

--- a/internal/apiserver/ui.go
+++ b/internal/apiserver/ui.go
@@ -1,0 +1,42 @@
+package apiserver
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+type UIHandler struct {
+	staticPath string
+	indexPath  string
+	urlPrefix  string
+}
+
+func (h UIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	path, err := filepath.Rel(h.urlPrefix, r.URL.Path)
+	if err != nil {
+		// if we failed to get the path respond with a 400 bad request
+		// and stop
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// prepend the path with the path to the static directory
+	path = filepath.Join(h.staticPath, path)
+
+	// check whether a file exists at the given path
+	_, err = os.Stat(path)
+	if os.IsNotExist(err) {
+		// file does not exist, serve index.html
+		http.ServeFile(w, r, filepath.Join(h.staticPath, h.indexPath))
+		return
+	} else if err != nil {
+		// if we got an error (that wasn't that the file doesn't exist) stating the
+		// file, return a 500 internal server error and stop
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// otherwise, use http.FileServer to serve the static dir
+	http.StripPrefix(h.urlPrefix, http.FileServer(http.Dir(h.staticPath))).ServeHTTP(w, r)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,9 +23,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kaleido-io/firefly/pkg/fftypes"
 	"github.com/kaleido-io/firefly/internal/i18n"
 	"github.com/kaleido-io/firefly/internal/log"
+	"github.com/kaleido-io/firefly/pkg/fftypes"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
@@ -70,6 +70,7 @@ var (
 	HttpTLSEnabled                 RootKey = ark("http.tls.enabled")
 	HttpTLSKeyFile                 RootKey = ark("http.tls.keyFile")
 	HttpWriteTimeout               RootKey = ark("http.writeTimeout")
+	UIPath                         RootKey = ark("ui.path")
 	Lang                           RootKey = ark("lang")
 	LogUTC                         RootKey = ark("log.utc")
 	LogNoColor                     RootKey = ark("log.noColor")


### PR DESCRIPTION
This PR adds the ability to serve a static HTML/CSS/JS frontend, if enabled in the config. This repo does not contain a frontend, so the config file will need to point to some place on the filesystem that a compiled frontend exists.

The following entry in `firefly.core` will serve HTML files from a directory called `frontend`.
```yaml
ui:
  path: frontend
```

> **NOTE**: The frontend is **not** enabled by default. If no `ui.path` key is present in the config file, the frontend will not be served.

The Dockerfile has also been updated to build the latest commit of https://github.com/kaleido-io/firefly-ui and include that in the image.