### PR TITLE
limit compiler version to max specified in the current openzeppelin d…

### DIFF
--- a/solidity_firefly/contracts/Firefly.sol
+++ b/solidity_firefly/contracts/Firefly.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pragma solidity >=0.6.0 <0.9.0;
+pragma solidity >=0.6.0 <0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
@@ -21,7 +21,7 @@ contract Firefly {
     }
 
     function broadcastBatch(bytes32 txnId, bytes32 batchId, bytes32 payloadRef) public {
-        emit BroadcastBatch(msg.sender, now, txnId, batchId, payloadRef);
+        emit BroadcastBatch(msg.sender, block.timestamp, txnId, batchId, payloadRef);
     }
 
 }


### PR DESCRIPTION
…ependency. remove now which is deprecated in favor of block.timestamp