### PR TITLE
Use "go install" instead of "go get" for installing CLI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kaleido-io/firefly
 
-go 1.15
+go 1.16
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -19,10 +19,6 @@ then
 	$CLI remove -f $STACK_NAME || true
 	$CLI init $STACK_NAME 2
 	$CLI start $STACK_NAME
-	# Stack doesn't come up cleanly the first time...
-	# TODO: fix this
-	$CLI stop $STACK_NAME
-	$CLI start $STACK_NAME
 fi
 
 export STACK_FILE

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -11,7 +11,7 @@ CREATE_STACK=true
 
 if $DOWNLOAD_CLI
 then
-	GO111MODULE=off go get github.com/kaleido-io/firefly-cli/ff
+	go install github.com/kaleido-io/firefly-cli/ff@latest
 fi
 
 if $CREATE_STACK


### PR DESCRIPTION
As of Go 1.16, "go install" is the cleanest way to install global
tools without messing up go.mod

See https://maelvls.dev/go111module-everywhere