### PR TITLE
Increase linter timeout to 5m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ coverage.html:
 		$(VGO) tool cover -html=coverage.txt
 coverage: test coverage.html
 lint:
-		$(shell go list -f '{{.Target}}' github.com/golangci/golangci-lint/cmd/golangci-lint) run -v
+		$(shell go list -f '{{.Target}}' github.com/golangci/golangci-lint/cmd/golangci-lint) run -v --timeout 5m
 mocks: ${GOFILES}
 		$(MOCKERY) --case underscore --dir pkg/blockchain        --name Plugin           --output mocks/blockchainmocks     --outpkg blockchainmocks
 		$(MOCKERY) --case underscore --dir pkg/blockchain        --name Callbacks        --output mocks/blockchainmocks     --outpkg blockchainmocks


### PR DESCRIPTION
I think we're just over the default threshold of 1 minute for `golangci-lint` when we run it in Docker Hub. Likely caused by reducing its memory usage, it runs more slowly now than it used to. This should get it to build in Docker Hub again.