### PR TITLE
Schema verification on aggregate

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,7 @@ linters-settings:
     enabled-tags:
       - performance
   goheader:
-    template: |
+    template: |-
       Copyright © {{ YEAR }} Kaleido, Inc.
       
       SPDX-License-Identifier: Apache-2.0
@@ -37,7 +37,7 @@ linters:
   - gocritic
   - gocyclo
   - gofmt
-  # - goheader
+  - goheader
   - goimports
   - goprintffuncname
   - gosec

--- a/cmd/firefly_test.go
+++ b/cmd/firefly_test.go
@@ -39,7 +39,7 @@ func TestExecMissingConfig(t *testing.T) {
 	defer func() { _utOrchestrator = nil }()
 	viper.Reset()
 	err := Execute()
-	assert.Regexp(t, "Not Found", err.Error())
+	assert.Regexp(t, "Not Found", err)
 }
 
 func TestShowConfig(t *testing.T) {
@@ -59,7 +59,7 @@ func TestExecEngineInitFail(t *testing.T) {
 	defer func() { _utOrchestrator = nil }()
 	os.Chdir(configDir)
 	err := Execute()
-	assert.Regexp(t, "splutter", err.Error())
+	assert.Regexp(t, "splutter", err)
 }
 
 func TestExecEngineStartFail(t *testing.T) {
@@ -70,7 +70,7 @@ func TestExecEngineStartFail(t *testing.T) {
 	defer func() { _utOrchestrator = nil }()
 	os.Chdir(configDir)
 	err := Execute()
-	assert.Regexp(t, "bang", err.Error())
+	assert.Regexp(t, "bang", err)
 }
 
 func TestExecOkExitSIGINT(t *testing.T) {

--- a/internal/apiserver/restfilter_test.go
+++ b/internal/apiserver/restfilter_test.go
@@ -41,7 +41,7 @@ func TestBuildFilterLimitSkip(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/things?skip=251", nil)
 	_, err := buildFilter(req, database.MessageQueryFactory)
-	assert.Regexp(t, "FF10183.*250", err.Error())
+	assert.Regexp(t, "FF10183.*250", err)
 }
 
 func TestBuildFilterLimitLimit(t *testing.T) {
@@ -49,5 +49,5 @@ func TestBuildFilterLimitLimit(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/things?limit=501", nil)
 	_, err := buildFilter(req, database.MessageQueryFactory)
-	assert.Regexp(t, "FF10184.*500", err.Error())
+	assert.Regexp(t, "FF10184.*500", err)
 }

--- a/internal/apiserver/route_get_msg_by_id.go
+++ b/internal/apiserver/route_get_msg_by_id.go
@@ -18,6 +18,7 @@ package apiserver
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/kaleido-io/firefly/internal/config"
 	"github.com/kaleido-io/firefly/internal/i18n"
@@ -33,14 +34,16 @@ var getMsgByID = &oapispec.Route{
 		{Name: "ns", ExampleFromConf: config.NamespacesDefault, Description: i18n.MsgTBD},
 		{Name: "msgid", Description: i18n.MsgTBD},
 	},
-	QueryParams:     nil,
+	QueryParams: []*oapispec.QueryParam{
+		{Name: "data", IsBool: true, Description: i18n.MsgTBD},
+	},
 	FilterFactory:   nil,
 	Description:     i18n.MsgTBD,
 	JSONInputValue:  nil,
-	JSONOutputValue: func() interface{} { return &fftypes.Message{} },
+	JSONOutputValue: func() interface{} { return &fftypes.MessageInput{} }, // can include full values, like on input
 	JSONOutputCode:  http.StatusOK,
 	JSONHandler: func(r oapispec.APIRequest) (output interface{}, err error) {
-		output, err = r.Or.GetMessageByID(r.Ctx, r.PP["ns"], r.PP["msgid"])
+		output, err = r.Or.GetMessageByID(r.Ctx, r.PP["ns"], r.PP["msgid"], strings.EqualFold(r.QP["data"], "true"))
 		return output, err
 	},
 }

--- a/internal/apiserver/route_get_msg_by_id_test.go
+++ b/internal/apiserver/route_get_msg_by_id_test.go
@@ -33,8 +33,22 @@ func TestGetMessageByID(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	res := httptest.NewRecorder()
 
-	o.On("GetMessageByID", mock.Anything, "mynamespace", "abcd12345").
-		Return(&fftypes.Message{}, nil)
+	o.On("GetMessageByID", mock.Anything, "mynamespace", "abcd12345", false).
+		Return(&fftypes.MessageInput{}, nil)
+	r.ServeHTTP(res, req)
+
+	assert.Equal(t, 200, res.Result().StatusCode)
+}
+
+func TestGetMessageByIDWithData(t *testing.T) {
+	o := &orchestratormocks.Orchestrator{}
+	r := createMuxRouter(o)
+	req := httptest.NewRequest("GET", "/api/v1/namespaces/mynamespace/messages/abcd12345?data", nil)
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	res := httptest.NewRecorder()
+
+	o.On("GetMessageByID", mock.Anything, "mynamespace", "abcd12345", true).
+		Return(&fftypes.MessageInput{}, nil)
 	r.ServeHTTP(res, req)
 
 	assert.Equal(t, 200, res.Result().StatusCode)

--- a/internal/apiserver/route_get_msg_data.go
+++ b/internal/apiserver/route_get_msg_data.go
@@ -25,22 +25,22 @@ import (
 	"github.com/kaleido-io/firefly/pkg/fftypes"
 )
 
-var postNewSubscription = &oapispec.Route{
-	Name:   "postNewSubscription",
-	Path:   "namespaces/{ns}/subscriptions",
-	Method: http.MethodPost,
+var getMsgData = &oapispec.Route{
+	Name:   "getMsgData",
+	Path:   "namespaces/{ns}/messages/{msgid}/data",
+	Method: http.MethodGet,
 	PathParams: []*oapispec.PathParam{
 		{Name: "ns", ExampleFromConf: config.NamespacesDefault, Description: i18n.MsgTBD},
+		{Name: "msgid", Description: i18n.MsgTBD},
 	},
 	QueryParams:     nil,
-	FilterFactory:   nil,
+	FilterFactory:   nil, // No filtering on this route - use namespaces/{ns}/data
 	Description:     i18n.MsgTBD,
-	JSONInputValue:  func() interface{} { return &fftypes.Subscription{} },
-	JSONInputMask:   []string{"ID", "Namespace", "Created", "Ephemeral"},
-	JSONOutputValue: func() interface{} { return &fftypes.Subscription{} },
-	JSONOutputCode:  http.StatusCreated, // Sync operation
+	JSONInputValue:  nil,
+	JSONOutputValue: func() interface{} { return []*fftypes.Data{} },
+	JSONOutputCode:  http.StatusOK,
 	JSONHandler: func(r oapispec.APIRequest) (output interface{}, err error) {
-		output, err = r.Or.CreateSubscription(r.Ctx, r.PP["ns"], r.Input.(*fftypes.Subscription))
+		output, err = r.Or.GetMessageData(r.Ctx, r.PP["ns"], r.PP["msgid"])
 		return output, err
 	},
 }

--- a/internal/apiserver/route_get_msg_data_test.go
+++ b/internal/apiserver/route_get_msg_data_test.go
@@ -17,8 +17,6 @@
 package apiserver
 
 import (
-	"bytes"
-	"encoding/json"
 	"net/http/httptest"
 	"testing"
 
@@ -28,19 +26,16 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-func TestPostNewSubscription(t *testing.T) {
+func TestGetMessageData(t *testing.T) {
 	o := &orchestratormocks.Orchestrator{}
 	r := createMuxRouter(o)
-	input := fftypes.Subscription{}
-	var buf bytes.Buffer
-	json.NewEncoder(&buf).Encode(&input)
-	req := httptest.NewRequest("POST", "/api/v1/namespaces/ns1/subscriptions", &buf)
+	req := httptest.NewRequest("GET", "/api/v1/namespaces/mynamespace/messages/uuid1/data", nil)
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	res := httptest.NewRecorder()
 
-	o.On("CreateSubscription", mock.Anything, "ns1", mock.AnythingOfType("*fftypes.Subscription")).
-		Return(&fftypes.Subscription{}, nil)
+	o.On("GetMessageData", mock.Anything, "mynamespace", "uuid1").
+		Return([]*fftypes.Data{}, nil)
 	r.ServeHTTP(res, req)
 
-	assert.Equal(t, 201, res.Result().StatusCode)
+	assert.Equal(t, 200, res.Result().StatusCode)
 }

--- a/internal/apiserver/route_post_broadcast_message.go
+++ b/internal/apiserver/route_post_broadcast_message.go
@@ -25,6 +25,58 @@ import (
 	"github.com/kaleido-io/firefly/pkg/fftypes"
 )
 
+var messageSchema = `{
+	"properties": {
+		 "data": {
+				"items": {
+					 "properties": {
+							"id": {"type": "string"},
+							"hash": {"type": "string"},
+							"validator": {"type": "string"},
+							"datatype": {
+								"type": "object",
+								"properties": {
+									"name": {"type": "string"},
+									"version": {"type": "string"}
+								}
+							},
+							"value": {
+								"type": "object"
+							}
+					 },
+					 "type": "object"
+				},
+				"type": "array"
+		 },
+		 "header": {
+				"properties": {
+					 "author": {
+							"type": "string"
+					 },
+					 "cid": {},
+					 "context": {
+							"type": "string"
+					 },
+					 "group": {},
+					 "topic": {
+							"type": "string"
+					 },
+					 "tx": {
+							"properties": {
+								 "type": {
+										"type": "string",
+										"default": "pin"
+								 }
+							},
+							"type": "object"
+					 }
+				},
+				"type": "object"
+		 }
+	},
+	"type": "object"
+}`
+
 var postBroadcastMessage = &oapispec.Route{
 	Name:   "postBroadcastMessage",
 	Path:   "namespaces/{ns}/broadcast/message",
@@ -36,7 +88,7 @@ var postBroadcastMessage = &oapispec.Route{
 	FilterFactory:   nil,
 	Description:     i18n.MsgTBD,
 	JSONInputValue:  func() interface{} { return &fftypes.MessageInput{} },
-	JSONInputMask:   []string{"Hash", "BatchID", "Sequence", "Confirmed"},
+	JSONInputSchema: messageSchema,
 	JSONOutputValue: func() interface{} { return &fftypes.Message{} },
 	JSONOutputCode:  http.StatusAccepted, // Async operation
 	JSONHandler: func(r oapispec.APIRequest) (output interface{}, err error) {

--- a/internal/apiserver/route_post_broadcast_message.go
+++ b/internal/apiserver/route_post_broadcast_message.go
@@ -1,0 +1,46 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"net/http"
+
+	"github.com/kaleido-io/firefly/internal/config"
+	"github.com/kaleido-io/firefly/internal/i18n"
+	"github.com/kaleido-io/firefly/internal/oapispec"
+	"github.com/kaleido-io/firefly/pkg/fftypes"
+)
+
+var postBroadcastMessage = &oapispec.Route{
+	Name:   "postBroadcastMessage",
+	Path:   "namespaces/{ns}/broadcast/message",
+	Method: http.MethodPost,
+	PathParams: []*oapispec.PathParam{
+		{Name: "ns", ExampleFromConf: config.NamespacesDefault, Description: i18n.MsgTBD},
+	},
+	QueryParams:     nil,
+	FilterFactory:   nil,
+	Description:     i18n.MsgTBD,
+	JSONInputValue:  func() interface{} { return &fftypes.MessageInput{} },
+	JSONInputMask:   []string{"Hash", "BatchID", "Sequence", "Confirmed"},
+	JSONOutputValue: func() interface{} { return &fftypes.Message{} },
+	JSONOutputCode:  http.StatusAccepted, // Async operation
+	JSONHandler: func(r oapispec.APIRequest) (output interface{}, err error) {
+		output, err = r.Or.BroadcastMessage(r.Ctx, r.PP["ns"], r.Input.(*fftypes.MessageInput))
+		return output, err
+	},
+}

--- a/internal/apiserver/route_post_broadcast_message_test.go
+++ b/internal/apiserver/route_post_broadcast_message_test.go
@@ -1,0 +1,46 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/kaleido-io/firefly/mocks/orchestratormocks"
+	"github.com/kaleido-io/firefly/pkg/fftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestPostBroadcastMessage(t *testing.T) {
+	o := &orchestratormocks.Orchestrator{}
+	r := createMuxRouter(o)
+	input := fftypes.Datatype{}
+	var buf bytes.Buffer
+	json.NewEncoder(&buf).Encode(&input)
+	req := httptest.NewRequest("POST", "/api/v1/namespaces/ns1/broadcast/message", &buf)
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	res := httptest.NewRecorder()
+
+	o.On("BroadcastMessage", mock.Anything, "ns1", mock.AnythingOfType("*fftypes.MessageInput")).
+		Return(&fftypes.Message{}, nil)
+	r.ServeHTTP(res, req)
+
+	assert.Equal(t, 202, res.Result().StatusCode)
+}

--- a/internal/apiserver/routes.go
+++ b/internal/apiserver/routes.go
@@ -30,6 +30,7 @@ var routes = []*oapispec.Route{
 	getEventByID,
 	getEvents,
 	getMsgByID,
+	getMsgData,
 	getMsgEvents,
 	getMsgOps,
 	getMsgs,

--- a/internal/apiserver/routes.go
+++ b/internal/apiserver/routes.go
@@ -37,11 +37,12 @@ var routes = []*oapispec.Route{
 	getNamespaces,
 	getOpByID,
 	getOps,
-	getSubsriptions,
 	getSubscriptionByID,
+	getSubsriptions,
 	getTxnByID,
 	getTxns,
 	postBroadcastDatatype,
+	postBroadcastMessage,
 	postBroadcastNamespace,
 	postNewSubscription,
 }

--- a/internal/apiserver/server.go
+++ b/internal/apiserver/server.go
@@ -181,8 +181,18 @@ func jsonHandler(o orchestrator.Orchestrator, route *oapispec.Route) http.Handle
 			}
 		}
 		queryParams := make(map[string]string)
-		for _, qp := range route.PathParams {
-			queryParams[qp.Name] = req.Form.Get(qp.Name)
+		for _, qp := range route.QueryParams {
+			val, exists := req.URL.Query()[qp.Name]
+			if qp.IsBool {
+				if exists && (len(val) == 0 || val[0] == "" || strings.EqualFold(val[0], "true")) {
+					val = []string{"true"}
+				} else {
+					val = []string{"false"}
+				}
+			}
+			if exists && len(val) > 0 {
+				queryParams[qp.Name] = val[0]
+			}
 		}
 		var filter database.AndFilter
 		if route.FilterFactory != nil {

--- a/internal/apiserver/server_test.go
+++ b/internal/apiserver/server_test.go
@@ -78,7 +78,7 @@ func TestMissingCAFile(t *testing.T) {
 	config.Set(config.HTTPTLSCAFile, "badness")
 	r := mux.NewRouter()
 	_, err := createServer(context.Background(), r)
-	assert.Regexp(t, "FF10105", err.Error())
+	assert.Regexp(t, "FF10105", err)
 }
 
 func TestBadCAFile(t *testing.T) {
@@ -86,7 +86,7 @@ func TestBadCAFile(t *testing.T) {
 	config.Set(config.HTTPTLSCAFile, configDir+"/firefly.core.yaml")
 	r := mux.NewRouter()
 	_, err := createServer(context.Background(), r)
-	assert.Regexp(t, "FF10106", err.Error())
+	assert.Regexp(t, "FF10106", err)
 }
 
 func TestTLSServerSelfSignedWithClientAuth(t *testing.T) {

--- a/internal/batch/batch_manager.go
+++ b/internal/batch/batch_manager.go
@@ -196,7 +196,7 @@ func (bm *batchManager) Close() {
 func (bm *batchManager) assembleMessageData(msg *fftypes.Message) (data []*fftypes.Data, err error) {
 	var foundAll = false
 	err = bm.retry.Do(bm.ctx, fmt.Sprintf("assemble message %s data", msg.Header.ID), func(attempt int) (retry bool, err error) {
-		data, foundAll, err = bm.data.GetMessageData(bm.ctx, msg)
+		data, foundAll, err = bm.data.GetMessageData(bm.ctx, msg, true)
 		// continual retry for persistence error (distinct from not-found)
 		return err != nil && !bm.closed, err
 	})

--- a/internal/blockchain/ethereum/ethereum_test.go
+++ b/internal/blockchain/ethereum/ethereum_test.go
@@ -51,7 +51,7 @@ func TestInitMissingURL(t *testing.T) {
 	e := &Ethereum{}
 	resetConf()
 	err := e.Init(context.Background(), utConfPrefix, &blockchainmocks.Callbacks{})
-	assert.Regexp(t, "FF10138.*url", err.Error())
+	assert.Regexp(t, "FF10138.*url", err)
 }
 
 func TestInitMissingInstance(t *testing.T) {
@@ -61,7 +61,7 @@ func TestInitMissingInstance(t *testing.T) {
 	utEthconnectConf.Set(EthconnectConfigTopic, "topic1")
 
 	err := e.Init(context.Background(), utConfPrefix, &blockchainmocks.Callbacks{})
-	assert.Regexp(t, "FF10138.*instance", err.Error())
+	assert.Regexp(t, "FF10138.*instance", err)
 }
 
 func TestInitMissingTopic(t *testing.T) {
@@ -71,7 +71,7 @@ func TestInitMissingTopic(t *testing.T) {
 	utEthconnectConf.Set(EthconnectConfigInstancePath, "/instances/0x12345")
 
 	err := e.Init(context.Background(), utConfPrefix, &blockchainmocks.Callbacks{})
-	assert.Regexp(t, "FF10138.*topic", err.Error())
+	assert.Regexp(t, "FF10138.*topic", err)
 }
 
 func TestInitAllNewStreamsAndWSEvent(t *testing.T) {
@@ -141,7 +141,7 @@ func TestWSInitFail(t *testing.T) {
 	utEthconnectConf.Set(EthconnectConfigSkipEventstreamInit, true)
 
 	err := e.Init(context.Background(), utConfPrefix, &blockchainmocks.Callbacks{})
-	assert.Regexp(t, "FF10162", err.Error())
+	assert.Regexp(t, "FF10162", err)
 
 }
 
@@ -209,8 +209,8 @@ func TestStreamQueryError(t *testing.T) {
 
 	err := e.Init(context.Background(), utConfPrefix, &blockchainmocks.Callbacks{})
 
-	assert.Regexp(t, "FF10111", err.Error())
-	assert.Regexp(t, "pop", err.Error())
+	assert.Regexp(t, "FF10111", err)
+	assert.Regexp(t, "pop", err)
 
 }
 
@@ -236,8 +236,8 @@ func TestStreamCreateError(t *testing.T) {
 
 	err := e.Init(context.Background(), utConfPrefix, &blockchainmocks.Callbacks{})
 
-	assert.Regexp(t, "FF10111", err.Error())
-	assert.Regexp(t, "pop", err.Error())
+	assert.Regexp(t, "FF10111", err)
+	assert.Regexp(t, "pop", err)
 
 }
 
@@ -265,8 +265,8 @@ func TestSubQueryError(t *testing.T) {
 
 	err := e.Init(context.Background(), utConfPrefix, &blockchainmocks.Callbacks{})
 
-	assert.Regexp(t, "FF10111", err.Error())
-	assert.Regexp(t, "pop", err.Error())
+	assert.Regexp(t, "FF10111", err)
+	assert.Regexp(t, "pop", err)
 
 }
 
@@ -296,8 +296,8 @@ func TestSubQueryCreateError(t *testing.T) {
 
 	err := e.Init(context.Background(), utConfPrefix, &blockchainmocks.Callbacks{})
 
-	assert.Regexp(t, "FF10111", err.Error())
-	assert.Regexp(t, "pop", err.Error())
+	assert.Regexp(t, "FF10111", err)
+	assert.Regexp(t, "pop", err)
 
 }
 
@@ -360,8 +360,8 @@ func TestSubmitBroadcastBatchFail(t *testing.T) {
 
 	_, err := e.SubmitBroadcastBatch(context.Background(), addr, batch)
 
-	assert.Regexp(t, "FF10111", err.Error())
-	assert.Regexp(t, "pop", err.Error())
+	assert.Regexp(t, "FF10111", err)
+	assert.Regexp(t, "pop", err)
 
 }
 
@@ -369,7 +369,7 @@ func TestVerifyEthAddress(t *testing.T) {
 	e := &Ethereum{}
 
 	_, err := e.VerifyIdentitySyntax(context.Background(), "0x12345")
-	assert.Regexp(t, "FF10141", err.Error())
+	assert.Regexp(t, "FF10141", err)
 
 	addr, err := e.VerifyIdentitySyntax(context.Background(), "0x2a7c9D5248681CE6c393117E641aD037F5C079F6")
 	assert.NoError(t, err)

--- a/internal/blockchain/utdbql/utdbql_test.go
+++ b/internal/blockchain/utdbql/utdbql_test.go
@@ -72,7 +72,7 @@ func TestVerifyIdentitySyntaxOK(t *testing.T) {
 func TestVerifyIdentitySyntaxFail(t *testing.T) {
 	u := &UTDBQL{}
 	_, err := u.VerifyIdentitySyntax(context.Background(), "!bad")
-	assert.Regexp(t, "FF10131", err.Error())
+	assert.Regexp(t, "FF10131", err)
 }
 
 func TestVerifyBroadcastBatchTXCycle(t *testing.T) {

--- a/internal/broadcast/broadcast_manager.go
+++ b/internal/broadcast/broadcast_manager.go
@@ -33,7 +33,7 @@ import (
 
 type Manager interface {
 	BroadcastMessage(ctx context.Context, msg *fftypes.Message) error
-	HandleSystemBroadcast(ctx context.Context, msg *fftypes.Message, data []*fftypes.Data) error
+	HandleSystemBroadcast(ctx context.Context, msg *fftypes.Message, data []*fftypes.Data) (valid bool, err error)
 	Start() error
 	WaitStop()
 }

--- a/internal/broadcast/broadcast_manager.go
+++ b/internal/broadcast/broadcast_manager.go
@@ -33,7 +33,7 @@ import (
 
 type Manager interface {
 	BroadcastMessage(ctx context.Context, msg *fftypes.Message) error
-	HandleSystemBroadcast(ctx context.Context, msg *fftypes.Message) error
+	HandleSystemBroadcast(ctx context.Context, msg *fftypes.Message, data []*fftypes.Data) error
 	Start() error
 	WaitStop()
 }

--- a/internal/broadcast/broadcast_manager_test.go
+++ b/internal/broadcast/broadcast_manager_test.go
@@ -45,7 +45,7 @@ func newTestBroadcast(ctx context.Context) (*broadcastManager, error) {
 
 func TestInitFail(t *testing.T) {
 	_, err := NewBroadcastManager(context.Background(), nil, nil, nil, nil, nil)
-	assert.Regexp(t, "FF10128", err.Error())
+	assert.Regexp(t, "FF10128", err)
 }
 
 func TestBroadcastMessageGood(t *testing.T) {
@@ -75,7 +75,7 @@ func TestBroadcastMessageBad(t *testing.T) {
 	bm.database.(*databasemocks.Plugin).On("UpsertMessage", mock.Anything, msg, false).Return(nil)
 
 	err = bm.BroadcastMessage(context.Background(), msg)
-	assert.Regexp(t, "FF10144", err.Error())
+	assert.Regexp(t, "FF10144", err)
 
 }
 
@@ -90,7 +90,7 @@ func TestDispatchBatchInvalidData(t *testing.T) {
 			},
 		},
 	})
-	assert.Regexp(t, "FF10137", err.Error())
+	assert.Regexp(t, "FF10137", err)
 }
 
 func TestDispatchBatchUploadFail(t *testing.T) {
@@ -131,7 +131,7 @@ func TestDispatchBatchSubmitBroadcastBatchFail(t *testing.T) {
 	dbMocks.On("UpsertTransaction", mock.Anything, mock.Anything, true, false).Return(fmt.Errorf("pop"))
 	fn := dbMocks.Calls[0].Arguments[1].(func(ctx context.Context) error)
 	err = fn(context.Background())
-	assert.Regexp(t, "pop", err.Error())
+	assert.Regexp(t, "pop", err)
 }
 
 func TestSubmitTXAndUpdateDBUpdateBatchFail(t *testing.T) {
@@ -144,7 +144,7 @@ func TestSubmitTXAndUpdateDBUpdateBatchFail(t *testing.T) {
 	bm.blockchain.(*blockchainmocks.Plugin).On("SubmitBroadcastBatch", mock.Anything, mock.Anything, mock.Anything).Return("", fmt.Errorf("pop"))
 
 	err = bm.submitTXAndUpdateDB(context.Background(), &fftypes.Batch{}, fftypes.NewRandB32(), "id1")
-	assert.Regexp(t, "pop", err.Error())
+	assert.Regexp(t, "pop", err)
 }
 
 func TestSubmitTXAndUpdateDBSubmitFail(t *testing.T) {
@@ -157,7 +157,7 @@ func TestSubmitTXAndUpdateDBSubmitFail(t *testing.T) {
 	bm.blockchain.(*blockchainmocks.Plugin).On("SubmitBroadcastBatch", mock.Anything, mock.Anything, mock.Anything).Return("", fmt.Errorf("pop"))
 
 	err = bm.submitTXAndUpdateDB(context.Background(), &fftypes.Batch{}, fftypes.NewRandB32(), "id1")
-	assert.Regexp(t, "pop", err.Error())
+	assert.Regexp(t, "pop", err)
 }
 
 func TestSubmitTXAndUpdateDBAddOp1Fail(t *testing.T) {
@@ -184,7 +184,7 @@ func TestSubmitTXAndUpdateDBAddOp1Fail(t *testing.T) {
 	}
 
 	err = bm.submitTXAndUpdateDB(context.Background(), batch, fftypes.NewRandB32(), "id1")
-	assert.Regexp(t, "pop", err.Error())
+	assert.Regexp(t, "pop", err)
 }
 
 func TestSubmitTXAndUpdateDBAddOp2Fail(t *testing.T) {
@@ -214,7 +214,7 @@ func TestSubmitTXAndUpdateDBAddOp2Fail(t *testing.T) {
 	}
 
 	err = bm.submitTXAndUpdateDB(context.Background(), batch, fftypes.NewRandB32(), "id1")
-	assert.Regexp(t, "pop", err.Error())
+	assert.Regexp(t, "pop", err)
 }
 
 func TestSubmitTXAndUpdateDBSucceed(t *testing.T) {

--- a/internal/broadcast/system_broadcasts.go
+++ b/internal/broadcast/system_broadcasts.go
@@ -40,7 +40,7 @@ func (bm *broadcastManager) HandleSystemBroadcast(ctx context.Context, msg *ffty
 
 func (bm *broadcastManager) getSystemBroadcastPayload(ctx context.Context, msg *fftypes.Message, res interface{}) (valid bool, err error) {
 	l := log.L(ctx)
-	data, allFound, err := bm.data.GetMessageData(ctx, msg)
+	data, allFound, err := bm.data.GetMessageData(ctx, msg, true)
 	if err != nil {
 		return false, err // only database errors are returned as an error (driving retry until we succeed)
 	}
@@ -99,7 +99,7 @@ func (bm *broadcastManager) handleDatatypeBroadcast(ctx context.Context, msg *ff
 		return nil
 	}
 
-	if err = bm.data.CheckDatatype(ctx, &dt); err != nil {
+	if err = bm.data.CheckDatatype(ctx, msg.Header.Namespace, &dt); err != nil {
 		l.Warnf("Unable to process datatype broadcast %s - schema check: %s", msg.Header.ID, err)
 		return nil
 	}

--- a/internal/broadcast/system_broadcasts_test.go
+++ b/internal/broadcast/system_broadcasts_test.go
@@ -43,7 +43,7 @@ func TestHandleSystemBroadcastUnknown(t *testing.T) {
 func TestGetSystemBroadcastPayloadMissingData(t *testing.T) {
 	bm, err := newTestBroadcast(context.Background())
 	mdm := bm.data.(*datamocks.Manager)
-	mdm.On("GetMessageData", mock.Anything, mock.Anything).Return([]*fftypes.Data{}, true, nil)
+	mdm.On("GetMessageData", mock.Anything, mock.Anything, true).Return([]*fftypes.Data{}, true, nil)
 	assert.NoError(t, err)
 	valid, err := bm.getSystemBroadcastPayload(context.Background(), &fftypes.Message{
 		Header: fftypes.MessageHeader{
@@ -57,7 +57,7 @@ func TestGetSystemBroadcastPayloadMissingData(t *testing.T) {
 func TestGetSystemBroadcastPayloadBadJSON(t *testing.T) {
 	bm, err := newTestBroadcast(context.Background())
 	mdm := bm.data.(*datamocks.Manager)
-	mdm.On("GetMessageData", mock.Anything, mock.Anything).Return([]*fftypes.Data{
+	mdm.On("GetMessageData", mock.Anything, mock.Anything, true).Return([]*fftypes.Data{
 		{ID: fftypes.NewUUID(), Value: fftypes.Byteable(`!json`)},
 	}, true, nil)
 	assert.NoError(t, err)
@@ -90,14 +90,15 @@ func TestHandleSystemBroadcastDatatypeOk(t *testing.T) {
 	}
 
 	mdm := bm.data.(*datamocks.Manager)
-	mdm.On("GetMessageData", mock.Anything, mock.Anything).Return([]*fftypes.Data{data}, true, nil)
-	mdm.On("CheckDatatype", mock.Anything, mock.Anything).Return(nil)
+	mdm.On("GetMessageData", mock.Anything, mock.Anything, true).Return([]*fftypes.Data{data}, true, nil)
+	mdm.On("CheckDatatype", mock.Anything, "ns1", mock.Anything).Return(nil)
 	mbi := bm.database.(*databasemocks.Plugin)
 	mbi.On("GetDatatypeByName", mock.Anything, "ns1", "name1", "ver1").Return(nil, nil)
 	mbi.On("UpsertDatatype", mock.Anything, mock.Anything, false).Return(nil)
 	err = bm.HandleSystemBroadcast(context.Background(), &fftypes.Message{
 		Header: fftypes.MessageHeader{
-			Topic: fftypes.SystemTopicBroadcastDatatype,
+			Namespace: "ns1",
+			Topic:     fftypes.SystemTopicBroadcastDatatype,
 		},
 	})
 	assert.NoError(t, err)
@@ -125,7 +126,7 @@ func TestHandleSystemBroadcastDatatypeMissingID(t *testing.T) {
 	}
 
 	mdm := bm.data.(*datamocks.Manager)
-	mdm.On("GetMessageData", mock.Anything, mock.Anything).Return([]*fftypes.Data{data}, true, nil)
+	mdm.On("GetMessageData", mock.Anything, mock.Anything, true).Return([]*fftypes.Data{data}, true, nil)
 	err = bm.HandleSystemBroadcast(context.Background(), &fftypes.Message{
 		Header: fftypes.MessageHeader{
 			Topic: fftypes.SystemTopicBroadcastDatatype,
@@ -156,11 +157,12 @@ func TestHandleSystemBroadcastBadSchema(t *testing.T) {
 	}
 
 	mdm := bm.data.(*datamocks.Manager)
-	mdm.On("GetMessageData", mock.Anything, mock.Anything).Return([]*fftypes.Data{data}, true, nil)
-	mdm.On("CheckDatatype", mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
+	mdm.On("GetMessageData", mock.Anything, mock.Anything, true).Return([]*fftypes.Data{data}, true, nil)
+	mdm.On("CheckDatatype", mock.Anything, "ns1", mock.Anything).Return(fmt.Errorf("pop"))
 	err = bm.HandleSystemBroadcast(context.Background(), &fftypes.Message{
 		Header: fftypes.MessageHeader{
-			Topic: fftypes.SystemTopicBroadcastDatatype,
+			Namespace: "ns1",
+			Topic:     fftypes.SystemTopicBroadcastDatatype,
 		},
 	})
 	assert.NoError(t, err)
@@ -187,7 +189,7 @@ func TestHandleSystemBroadcastGetMessageDataFile(t *testing.T) {
 	}
 
 	mdm := bm.data.(*datamocks.Manager)
-	mdm.On("GetMessageData", mock.Anything, mock.Anything).Return([]*fftypes.Data{data}, false, fmt.Errorf("pop"))
+	mdm.On("GetMessageData", mock.Anything, mock.Anything, true).Return([]*fftypes.Data{data}, false, fmt.Errorf("pop"))
 	err = bm.HandleSystemBroadcast(context.Background(), &fftypes.Message{
 		Header: fftypes.MessageHeader{
 			Topic: fftypes.SystemTopicBroadcastDatatype,
@@ -213,7 +215,7 @@ func TestHandleSystemBroadcastMissingData(t *testing.T) {
 	dt.Hash = dt.Value.Hash()
 
 	mdm := bm.data.(*datamocks.Manager)
-	mdm.On("GetMessageData", mock.Anything, mock.Anything).Return(nil, false, nil)
+	mdm.On("GetMessageData", mock.Anything, mock.Anything, true).Return(nil, false, nil)
 	err = bm.HandleSystemBroadcast(context.Background(), &fftypes.Message{
 		Header: fftypes.MessageHeader{
 			Topic: fftypes.SystemTopicBroadcastDatatype,
@@ -244,13 +246,14 @@ func TestHandleSystemBroadcastDatatypeLookupFail(t *testing.T) {
 	}
 
 	mdm := bm.data.(*datamocks.Manager)
-	mdm.On("GetMessageData", mock.Anything, mock.Anything).Return([]*fftypes.Data{data}, true, nil)
-	mdm.On("CheckDatatype", mock.Anything, mock.Anything).Return(nil)
+	mdm.On("GetMessageData", mock.Anything, mock.Anything, true).Return([]*fftypes.Data{data}, true, nil)
+	mdm.On("CheckDatatype", mock.Anything, "ns1", mock.Anything).Return(nil)
 	mbi := bm.database.(*databasemocks.Plugin)
 	mbi.On("GetDatatypeByName", mock.Anything, "ns1", "name1", "ver1").Return(nil, fmt.Errorf("pop"))
 	err = bm.HandleSystemBroadcast(context.Background(), &fftypes.Message{
 		Header: fftypes.MessageHeader{
-			Topic: fftypes.SystemTopicBroadcastDatatype,
+			Namespace: "ns1",
+			Topic:     fftypes.SystemTopicBroadcastDatatype,
 		},
 	})
 	assert.EqualError(t, err, "pop")
@@ -279,13 +282,14 @@ func TestHandleSystemBroadcastDatatypeDuplicate(t *testing.T) {
 	}
 
 	mdm := bm.data.(*datamocks.Manager)
-	mdm.On("GetMessageData", mock.Anything, mock.Anything).Return([]*fftypes.Data{data}, true, nil)
-	mdm.On("CheckDatatype", mock.Anything, mock.Anything).Return(nil)
+	mdm.On("GetMessageData", mock.Anything, mock.Anything, true).Return([]*fftypes.Data{data}, true, nil)
+	mdm.On("CheckDatatype", mock.Anything, "ns1", mock.Anything).Return(nil)
 	mbi := bm.database.(*databasemocks.Plugin)
 	mbi.On("GetDatatypeByName", mock.Anything, "ns1", "name1", "ver1").Return(dt, nil)
 	err = bm.HandleSystemBroadcast(context.Background(), &fftypes.Message{
 		Header: fftypes.MessageHeader{
-			Topic: fftypes.SystemTopicBroadcastDatatype,
+			Namespace: "ns1",
+			Topic:     fftypes.SystemTopicBroadcastDatatype,
 		},
 	})
 	assert.NoError(t, err)
@@ -309,7 +313,7 @@ func TestHandleSystemBroadcastNSOk(t *testing.T) {
 	}
 
 	mdm := bm.data.(*datamocks.Manager)
-	mdm.On("GetMessageData", mock.Anything, mock.Anything).Return([]*fftypes.Data{data}, true, nil)
+	mdm.On("GetMessageData", mock.Anything, mock.Anything, true).Return([]*fftypes.Data{data}, true, nil)
 	mbi := bm.database.(*databasemocks.Plugin)
 	mbi.On("GetNamespace", mock.Anything, "ns1").Return(nil, nil)
 	mbi.On("UpsertNamespace", mock.Anything, mock.Anything, true).Return(nil)
@@ -329,7 +333,7 @@ func TestHandleSystemBroadcastNSMissingData(t *testing.T) {
 	assert.NoError(t, err)
 
 	mdm := bm.data.(*datamocks.Manager)
-	mdm.On("GetMessageData", mock.Anything, mock.Anything).Return(nil, false, nil)
+	mdm.On("GetMessageData", mock.Anything, mock.Anything, true).Return(nil, false, nil)
 	err = bm.HandleSystemBroadcast(context.Background(), &fftypes.Message{
 		Header: fftypes.MessageHeader{
 			Topic: fftypes.SystemTopicBroadcastNamespace,
@@ -352,7 +356,7 @@ func TestHandleSystemBroadcastNSBadID(t *testing.T) {
 	}
 
 	mdm := bm.data.(*datamocks.Manager)
-	mdm.On("GetMessageData", mock.Anything, mock.Anything).Return([]*fftypes.Data{data}, true, nil)
+	mdm.On("GetMessageData", mock.Anything, mock.Anything, true).Return([]*fftypes.Data{data}, true, nil)
 	err = bm.HandleSystemBroadcast(context.Background(), &fftypes.Message{
 		Header: fftypes.MessageHeader{
 			Topic: fftypes.SystemTopicBroadcastNamespace,
@@ -378,7 +382,7 @@ func TestHandleSystemBroadcastDuplicate(t *testing.T) {
 	}
 
 	mdm := bm.data.(*datamocks.Manager)
-	mdm.On("GetMessageData", mock.Anything, mock.Anything).Return([]*fftypes.Data{data}, true, nil)
+	mdm.On("GetMessageData", mock.Anything, mock.Anything, true).Return([]*fftypes.Data{data}, true, nil)
 	mbi := bm.database.(*databasemocks.Plugin)
 	mbi.On("GetNamespace", mock.Anything, "ns1").Return(ns, nil)
 	err = bm.HandleSystemBroadcast(context.Background(), &fftypes.Message{
@@ -407,7 +411,7 @@ func TestHandleSystemBroadcastDupCheckFail(t *testing.T) {
 	}
 
 	mdm := bm.data.(*datamocks.Manager)
-	mdm.On("GetMessageData", mock.Anything, mock.Anything).Return([]*fftypes.Data{data}, true, nil)
+	mdm.On("GetMessageData", mock.Anything, mock.Anything, true).Return([]*fftypes.Data{data}, true, nil)
 	mbi := bm.database.(*databasemocks.Plugin)
 	mbi.On("GetNamespace", mock.Anything, "ns1").Return(nil, fmt.Errorf("pop"))
 	err = bm.HandleSystemBroadcast(context.Background(), &fftypes.Message{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -32,7 +32,7 @@ const configDir = "../../test/data/config"
 func TestInitConfigOK(t *testing.T) {
 	viper.Reset()
 	err := ReadConfig("")
-	assert.Regexp(t, "Not Found", err.Error())
+	assert.Regexp(t, "Not Found", err)
 }
 
 func TestDefaults(t *testing.T) {

--- a/internal/data/data_manager.go
+++ b/internal/data/data_manager.go
@@ -30,13 +30,20 @@ import (
 )
 
 type Manager interface {
-	CheckDatatype(ctx context.Context, datatype *fftypes.Datatype) error
+	CheckDatatype(ctx context.Context, ns string, datatype *fftypes.Datatype) error
 	GetValidator(ctx context.Context, data *fftypes.Data) (Validator, error)
-	GetMessageData(ctx context.Context, msg *fftypes.Message) (data []*fftypes.Data, foundAll bool, err error)
+	GetMessageData(ctx context.Context, msg *fftypes.Message, withValue bool) (data []*fftypes.Data, foundAll bool, err error)
+	ResolveInputData(ctx context.Context, ns string, inData fftypes.InputData) (fftypes.DataRefs, error)
 }
 
 type dataManager struct {
-	ctx               context.Context
+
+	// Note that we don't store a context in dataManager, as it doesn't currently have long-running
+	// background tasks. All of the APIs for actions take a context, which might include a database
+	// transaction - so it's important that we use that passed context for all of those synchronous calls.
+	// If a context is introduce for long lived tasks, to avoid accidental use of it on API calls,
+	// that should be stored on a sub structure associated with that long-lived task.
+
 	database          database.Plugin
 	validatorCache    *ccache.Cache
 	validatorCacheTTL time.Duration
@@ -47,7 +54,6 @@ func NewDataManager(ctx context.Context, di database.Plugin) (Manager, error) {
 		return nil, i18n.NewError(ctx, i18n.MsgInitializationNilDepError)
 	}
 	dm := &dataManager{
-		ctx:               ctx,
 		database:          di,
 		validatorCacheTTL: config.GetDuration(config.ValidatorCacheTTL),
 	}
@@ -59,69 +65,151 @@ func NewDataManager(ctx context.Context, di database.Plugin) (Manager, error) {
 	return dm, nil
 }
 
-func (dm *dataManager) CheckDatatype(ctx context.Context, datatype *fftypes.Datatype) error {
-	_, err := newJSONValidator(ctx, datatype)
+func (dm *dataManager) CheckDatatype(ctx context.Context, ns string, datatype *fftypes.Datatype) error {
+	_, err := newJSONValidator(ctx, ns, datatype)
 	return err
 }
 
 func (dm *dataManager) GetValidator(ctx context.Context, data *fftypes.Data) (Validator, error) {
-	if data.Validator == "" {
-		data.Validator = fftypes.ValidatorTypeJSON
+	return dm.getValidatorForDatatype(ctx, data.Namespace, data.Validator, data.Datatype)
+}
+
+func (dm *dataManager) getValidatorForDatatype(ctx context.Context, ns string, validator fftypes.ValidatorType, datatypeRef *fftypes.DatatypeRef) (Validator, error) {
+	if validator == "" {
+		validator = fftypes.ValidatorTypeJSON
 	}
-	if data.Validator != fftypes.ValidatorTypeJSON {
-		return nil, i18n.NewError(ctx, i18n.MsgUnknownValidatorType, data.Validator)
+	if validator != fftypes.ValidatorTypeJSON {
+		return nil, i18n.NewError(ctx, i18n.MsgUnknownValidatorType, validator)
 	}
 
-	if data.Datatype == nil || data.Datatype.Name == "" || data.Datatype.Version == "" {
-		return nil, i18n.NewError(ctx, i18n.MsgDatatypeNotFound, data.Datatype)
+	if datatypeRef == nil || datatypeRef.Name == "" || datatypeRef.Version == "" {
+		return nil, i18n.NewError(ctx, i18n.MsgDatatypeNotFound, datatypeRef)
 	}
 
-	key := fmt.Sprintf("%s:%s:%s", data.Namespace, data.Validator, data.Datatype)
-	validator, err := dm.validatorCache.Fetch(key, dm.validatorCacheTTL, func() (interface{}, error) {
-		datatype, err := dm.database.GetDatatypeByName(dm.ctx, data.Namespace, data.Datatype.Name, data.Datatype.Version)
+	key := fmt.Sprintf("%s:%s:%s", ns, validator, datatypeRef)
+	v, err := dm.validatorCache.Fetch(key, dm.validatorCacheTTL, func() (interface{}, error) {
+		datatype, err := dm.database.GetDatatypeByName(ctx, ns, datatypeRef.Name, datatypeRef.Version)
 		if err != nil {
 			return nil, err
 		}
 		if datatype == nil {
-			return nil, i18n.NewError(ctx, i18n.MsgDatatypeNotFound, data.Datatype.Name)
+			return nil, i18n.NewError(ctx, i18n.MsgDatatypeNotFound, datatypeRef.Name)
 		}
-		return newJSONValidator(ctx, datatype)
+		return newJSONValidator(ctx, ns, datatype)
 	})
 	if err != nil {
 		return nil, err
 	}
-	v := validator.Value().(*jsonValidator)
-	log.L(ctx).Debugf("Found JSON schema validator for %s: %v", key, v.id)
-	return v, err
+	return v.Value().(Validator), err
 }
 
 // GetMessageData looks for all the data attached to the message.
 // It only returns persistence errors.
 // For all cases where the data is not found (or the hashes mismatch)
-func (dm *dataManager) GetMessageData(ctx context.Context, msg *fftypes.Message) (data []*fftypes.Data, foundAll bool, err error) {
+func (dm *dataManager) GetMessageData(ctx context.Context, msg *fftypes.Message, withValue bool) (data []*fftypes.Data, foundAll bool, err error) {
 	// Load all the data - must all be present for us to send
 	data = make([]*fftypes.Data, 0, len(msg.Data))
 	foundAll = true
 	for i, dataRef := range msg.Data {
-		if dataRef == nil || dataRef.ID == nil {
-			log.L(ctx).Warnf("Message %v data %d is nil", msg.Header.ID, i)
-			foundAll = false
-			continue
-		}
-		d, err := dm.database.GetDataByID(ctx, dataRef.ID)
+		d, err := dm.resolveRef(ctx, msg.Header.Namespace, dataRef, withValue)
 		if err != nil {
 			return nil, false, err
 		}
-		switch {
-		case d == nil:
-			log.L(ctx).Warnf("Message %v missing data %v", msg.Header.ID, dataRef.ID)
+		if d == nil {
+			log.L(ctx).Warnf("Message %v data %d mising", msg.Header.ID, i)
 			foundAll = false
-		case d.Hash == nil || dataRef.Hash == nil || *d.Hash != *dataRef.Hash:
-			log.L(ctx).Warnf("Message %v data %d hash does not match. Hash=%v Expected=%v", msg.Header.ID, i, d.Hash, dataRef.Hash)
-			foundAll = false
-		default:
-			data = append(data, d)
+			continue
 		}
+		data = append(data, d)
 	}
 	return data, foundAll, nil
+}
+
+func (dm *dataManager) resolveRef(ctx context.Context, ns string, dataRef *fftypes.DataRef, withValue bool) (*fftypes.Data, error) {
+	if dataRef == nil || dataRef.ID == nil {
+		log.L(ctx).Warnf("data is nil")
+		return nil, nil
+	}
+	d, err := dm.database.GetDataByID(ctx, dataRef.ID, withValue)
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case d == nil || d.Namespace != ns:
+		log.L(ctx).Warnf("Data %s not found in namespace %s", dataRef.ID, ns)
+		return nil, nil
+	case d.Hash == nil || (dataRef.Hash != nil && *d.Hash != *dataRef.Hash):
+		log.L(ctx).Warnf("Data hash does not match. Hash=%v Expected=%v", d.Hash, dataRef.Hash)
+		return nil, nil
+	default:
+		return d, nil
+	}
+}
+
+func (dm *dataManager) validateAndStore(ctx context.Context, ns string, value *fftypes.DataRefOrValue) (*fftypes.DataRef, error) {
+
+	// If a datatype is specified, we need to verify the payload conforms
+	if value.Datatype != nil {
+		v, err := dm.getValidatorForDatatype(ctx, ns, value.Validator, value.Datatype)
+		if err != nil {
+			return nil, err
+		}
+		err = v.ValidateValue(ctx, value.Value, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Ok, we're good to generate the full data payload and save it
+	data := &fftypes.Data{
+		Validator: value.Validator,
+		Datatype:  value.Datatype,
+		Namespace: ns,
+		Hash:      value.Hash,
+		Value:     value.Value,
+	}
+	err := data.Seal(ctx)
+	if err == nil {
+		err = dm.database.UpsertData(ctx, data, false, false)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Return a ref to the newly saved data
+	return &fftypes.DataRef{
+		ID:   data.ID,
+		Hash: data.Hash,
+	}, nil
+}
+
+func (dm *dataManager) ResolveInputData(ctx context.Context, ns string, inData fftypes.InputData) (refs fftypes.DataRefs, err error) {
+
+	refs = make(fftypes.DataRefs, len(inData))
+	for i, dataOrValue := range inData {
+		switch {
+		case dataOrValue.ID != nil:
+			// If an ID is supplied, then it must be a reference to existing data
+			d, err := dm.resolveRef(ctx, ns, &dataOrValue.DataRef, false /* do not need the value */)
+			if err != nil {
+				return nil, err
+			}
+			if d == nil {
+				return nil, i18n.NewError(ctx, i18n.MsgDataReferenceUnresolvable, i)
+			}
+			refs[i] = &fftypes.DataRef{
+				ID:   d.ID,
+				Hash: d.Hash,
+			}
+		case dataOrValue.Value != nil:
+			// We've got a Value, so we can validate + store it
+			if refs[i], err = dm.validateAndStore(ctx, ns, dataOrValue); err != nil {
+				return nil, err
+			}
+		default:
+			// We have neither - this must be a mistake
+			return nil, i18n.NewError(ctx, i18n.MsgDataMissing, i)
+		}
+	}
+	return refs, nil
 }

--- a/internal/data/json_validator.go
+++ b/internal/data/json_validator.go
@@ -53,7 +53,7 @@ func newJSONValidator(ctx context.Context, ns string, datatype *fftypes.Datatype
 	jv.schema = schema
 	jv.size = int64(len(schemaBytes))
 
-	log.L(ctx).Debugf("Found JSON schema validator for %s/%s: %v", datatype, jv.ns, jv.id)
+	log.L(ctx).Debugf("Found JSON schema validator for json:%s:%s: %v", jv.ns, datatype, jv.id)
 	return jv, nil
 }
 

--- a/internal/data/json_validator_test.go
+++ b/internal/data/json_validator_test.go
@@ -42,17 +42,17 @@ func TestJSONValidator(t *testing.T) {
 		Value:     fftypes.Byteable(schemaBinary),
 	}
 
-	jv, err := newJSONValidator(context.Background(), dt)
+	jv, err := newJSONValidator(context.Background(), "ns1", dt)
 	assert.NoError(t, err)
 
 	err = jv.validateBytes(context.Background(), []byte(`{}`))
-	assert.Regexp(t, "FF10198.*prop1", err.Error())
+	assert.Regexp(t, "FF10198.*prop1", err)
 
 	err = jv.validateBytes(context.Background(), []byte(`{"prop1": "a value"}`))
 	assert.NoError(t, err)
 
 	err = jv.validateBytes(context.Background(), []byte(`{!bad json`))
-	assert.Regexp(t, "FF10197", err.Error())
+	assert.Regexp(t, "FF10197", err)
 
 	assert.Equal(t, int64(len(schemaBinary)), jv.Size())
 
@@ -67,8 +67,8 @@ func TestJSONValidatorParseSchemaFail(t *testing.T) {
 		Value:     fftypes.Byteable(`{!json`),
 	}
 
-	_, err := newJSONValidator(context.Background(), dt)
-	assert.Regexp(t, "FF10196", err.Error())
+	_, err := newJSONValidator(context.Background(), "ns1", dt)
+	assert.Regexp(t, "FF10196", err)
 
 }
 
@@ -76,6 +76,6 @@ func TestJSONValidatorNilData(t *testing.T) {
 
 	v := &jsonValidator{}
 	err := v.Validate(context.Background(), &fftypes.Data{})
-	assert.Regexp(t, "FF10199", err.Error())
+	assert.Regexp(t, "FF10199", err)
 
 }

--- a/internal/data/validator.go
+++ b/internal/data/validator.go
@@ -24,5 +24,6 @@ import (
 
 type Validator interface {
 	Validate(ctx context.Context, data *fftypes.Data) error
+	ValidateValue(ctx context.Context, value fftypes.Byteable, expectedHash *fftypes.Bytes32) error
 	Size() int64 // for cache management
 }

--- a/internal/database/sqlcommon/batch_sql_test.go
+++ b/internal/database/sqlcommon/batch_sql_test.go
@@ -147,7 +147,7 @@ func TestUpsertBatchFailBegin(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertBatch(context.Background(), &fftypes.Batch{}, true, true)
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -158,7 +158,7 @@ func TestUpsertBatchFailSelect(t *testing.T) {
 	mock.ExpectRollback()
 	batchID := fftypes.NewUUID()
 	err := s.UpsertBatch(context.Background(), &fftypes.Batch{ID: batchID}, true, true)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -170,7 +170,7 @@ func TestUpsertBatchFailInsert(t *testing.T) {
 	mock.ExpectRollback()
 	batchID := fftypes.NewUUID()
 	err := s.UpsertBatch(context.Background(), &fftypes.Batch{ID: batchID}, true, true)
-	assert.Regexp(t, "FF10116", err.Error())
+	assert.Regexp(t, "FF10116", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -182,7 +182,7 @@ func TestUpsertBatchFailUpdate(t *testing.T) {
 	mock.ExpectExec("UPDATE .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	err := s.UpsertBatch(context.Background(), &fftypes.Batch{ID: batchID}, true, true)
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -194,7 +194,7 @@ func TestUpsertBatchFailCommit(t *testing.T) {
 	mock.ExpectExec("INSERT .*").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertBatch(context.Background(), &fftypes.Batch{ID: batchID}, true, true)
-	assert.Regexp(t, "FF10119", err.Error())
+	assert.Regexp(t, "FF10119", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -203,7 +203,7 @@ func TestGetBatchByIDSelectFail(t *testing.T) {
 	batchID := fftypes.NewUUID()
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	_, err := s.GetBatchByID(context.Background(), batchID)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -222,7 +222,7 @@ func TestGetBatchByIDScanFail(t *testing.T) {
 	batchID := fftypes.NewUUID()
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("only one"))
 	_, err := s.GetBatchByID(context.Background(), batchID)
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -231,7 +231,7 @@ func TestGetBatchesQueryFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	f := database.BatchQueryFactory.NewFilter(context.Background()).Eq("id", "")
 	_, err := s.GetBatches(context.Background(), f)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -239,7 +239,7 @@ func TestGetBatchesBuildQueryFail(t *testing.T) {
 	s, _ := newMockProvider().init()
 	f := database.BatchQueryFactory.NewFilter(context.Background()).Eq("id", map[bool]bool{true: false})
 	_, err := s.GetBatches(context.Background(), f)
-	assert.Regexp(t, "FF10149.*id", err.Error())
+	assert.Regexp(t, "FF10149.*id", err)
 }
 
 func TestGetBatchesReadMessageFail(t *testing.T) {
@@ -247,7 +247,7 @@ func TestGetBatchesReadMessageFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("only one"))
 	f := database.BatchQueryFactory.NewFilter(context.Background()).Eq("id", "")
 	_, err := s.GetBatches(context.Background(), f)
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -256,7 +256,7 @@ func TestBatchUpdateBeginFail(t *testing.T) {
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	u := database.BatchQueryFactory.NewUpdate(context.Background()).Set("id", "anything")
 	err := s.UpdateBatch(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 }
 
 func TestBatchUpdateBuildQueryFail(t *testing.T) {
@@ -264,7 +264,7 @@ func TestBatchUpdateBuildQueryFail(t *testing.T) {
 	mock.ExpectBegin()
 	u := database.BatchQueryFactory.NewUpdate(context.Background()).Set("id", map[bool]bool{true: false})
 	err := s.UpdateBatch(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10149.*id", err.Error())
+	assert.Regexp(t, "FF10149.*id", err)
 }
 
 func TestBatchUpdateFail(t *testing.T) {
@@ -274,5 +274,5 @@ func TestBatchUpdateFail(t *testing.T) {
 	mock.ExpectRollback()
 	u := database.BatchQueryFactory.NewUpdate(context.Background()).Set("id", fftypes.NewUUID())
 	err := s.UpdateBatch(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 }

--- a/internal/database/sqlcommon/blocked_sql_test.go
+++ b/internal/database/sqlcommon/blocked_sql_test.go
@@ -124,7 +124,7 @@ func TestUpsertBlockedFailBegin(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertBlocked(context.Background(), &fftypes.Blocked{}, true)
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -134,7 +134,7 @@ func TestUpsertBlockedFailSelect(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	err := s.UpsertBlocked(context.Background(), &fftypes.Blocked{Context: "context1"}, true)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -145,7 +145,7 @@ func TestUpsertBlockedFailInsert(t *testing.T) {
 	mock.ExpectExec("INSERT .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	err := s.UpsertBlocked(context.Background(), &fftypes.Blocked{Context: "context1"}, true)
-	assert.Regexp(t, "FF10116", err.Error())
+	assert.Regexp(t, "FF10116", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -157,7 +157,7 @@ func TestUpsertBlockedFailUpdate(t *testing.T) {
 	mock.ExpectExec("UPDATE .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	err := s.UpsertBlocked(context.Background(), &fftypes.Blocked{Context: "context1"}, true)
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -168,7 +168,7 @@ func TestUpsertBlockedFailCommit(t *testing.T) {
 	mock.ExpectExec("INSERT .*").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertBlocked(context.Background(), &fftypes.Blocked{Context: "context1"}, true)
-	assert.Regexp(t, "FF10119", err.Error())
+	assert.Regexp(t, "FF10119", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -176,7 +176,7 @@ func TestGetBlockedByIDSelectFail(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	_, err := s.GetBlockedByContext(context.Background(), "ns1", "context1", nil)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -193,7 +193,7 @@ func TestGetBlockedByIDScanFail(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"context"}).AddRow("only one"))
 	_, err := s.GetBlockedByContext(context.Background(), "ns1", "context1", nil)
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -202,7 +202,7 @@ func TestGetBlockedQueryFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	f := database.BlockedQueryFactory.NewFilter(context.Background()).Eq("context", "")
 	_, err := s.GetBlocked(context.Background(), f)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -210,7 +210,7 @@ func TestGetBlockedBuildQueryFail(t *testing.T) {
 	s, _ := newMockProvider().init()
 	f := database.BlockedQueryFactory.NewFilter(context.Background()).Eq("context", map[bool]bool{true: false})
 	_, err := s.GetBlocked(context.Background(), f)
-	assert.Regexp(t, "FF10149.*type", err.Error())
+	assert.Regexp(t, "FF10149.*type", err)
 }
 
 func TestGetBlockedReadMessageFail(t *testing.T) {
@@ -218,7 +218,7 @@ func TestGetBlockedReadMessageFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"context"}).AddRow("only one"))
 	f := database.BlockedQueryFactory.NewFilter(context.Background()).Eq("context", "")
 	_, err := s.GetBlocked(context.Background(), f)
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -227,7 +227,7 @@ func TestBlockedUpdateBeginFail(t *testing.T) {
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	u := database.BlockedQueryFactory.NewUpdate(context.Background()).Set("context", "anything")
 	err := s.UpdateBlocked(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 }
 
 func TestBlockedUpdateBuildQueryFail(t *testing.T) {
@@ -235,7 +235,7 @@ func TestBlockedUpdateBuildQueryFail(t *testing.T) {
 	mock.ExpectBegin()
 	u := database.BlockedQueryFactory.NewUpdate(context.Background()).Set("context", map[bool]bool{true: false})
 	err := s.UpdateBlocked(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10149.*context", err.Error())
+	assert.Regexp(t, "FF10149.*context", err)
 }
 
 func TestBlockedUpdateFail(t *testing.T) {
@@ -245,14 +245,14 @@ func TestBlockedUpdateFail(t *testing.T) {
 	mock.ExpectRollback()
 	u := database.BlockedQueryFactory.NewUpdate(context.Background()).Set("context", fftypes.NewUUID())
 	err := s.UpdateBlocked(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 }
 
 func TestBlockedDeleteBeginFail(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	err := s.DeleteBlocked(context.Background(), fftypes.NewUUID())
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 }
 
 func TestBlockedDeleteFail(t *testing.T) {
@@ -261,5 +261,5 @@ func TestBlockedDeleteFail(t *testing.T) {
 	mock.ExpectExec("DELETE .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	err := s.DeleteBlocked(context.Background(), fftypes.NewUUID())
-	assert.Regexp(t, "FF10118", err.Error())
+	assert.Regexp(t, "FF10118", err)
 }

--- a/internal/database/sqlcommon/data_sql_test.go
+++ b/internal/database/sqlcommon/data_sql_test.go
@@ -52,12 +52,17 @@ func TestDataE2EWithDB(t *testing.T) {
 		Created:   fftypes.Now(),
 		Value:     []byte(val.String()),
 	}
-	err := s.UpsertData(ctx, data, true, true)
+	err := s.UpsertData(ctx, data, true, false)
 	assert.NoError(t, err)
 
-	// Check we get the exact same data back
-	dataRead, err := s.GetDataByID(ctx, dataID)
+	// Check we get the exact same data back - we should not to return the value first
+	dataRead, err := s.GetDataByID(ctx, dataID, false)
 	assert.NoError(t, err)
+	assert.Equal(t, *dataID, *dataRead.ID)
+	assert.Nil(t, dataRead.Value)
+
+	// Now with value
+	dataRead, err = s.GetDataByID(ctx, dataID, true)
 	assert.NotNil(t, dataRead)
 	dataJson, _ := json.Marshal(&data)
 	dataReadJson, _ := json.Marshal(&dataRead)
@@ -93,7 +98,7 @@ func TestDataE2EWithDB(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check we get the exact same message back - note the removal of one of the data elements
-	dataRead, err = s.GetDataByID(ctx, dataID)
+	dataRead, err = s.GetDataByID(ctx, dataID, true)
 	assert.NoError(t, err)
 	dataJson, _ = json.Marshal(&dataUpdated)
 	dataReadJson, _ = json.Marshal(&dataRead)
@@ -160,7 +165,7 @@ func TestUpsertDataFailBegin(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertData(context.Background(), &fftypes.Data{}, true, true)
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -171,7 +176,7 @@ func TestUpsertDataFailSelect(t *testing.T) {
 	mock.ExpectRollback()
 	dataID := fftypes.NewUUID()
 	err := s.UpsertData(context.Background(), &fftypes.Data{ID: dataID}, true, true)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -183,7 +188,7 @@ func TestUpsertDataFailInsert(t *testing.T) {
 	mock.ExpectRollback()
 	dataID := fftypes.NewUUID()
 	err := s.UpsertData(context.Background(), &fftypes.Data{ID: dataID}, true, true)
-	assert.Regexp(t, "FF10116", err.Error())
+	assert.Regexp(t, "FF10116", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -195,7 +200,7 @@ func TestUpsertDataFailUpdate(t *testing.T) {
 	mock.ExpectExec("UPDATE .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	err := s.UpsertData(context.Background(), &fftypes.Data{ID: dataID}, true, true)
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -207,7 +212,7 @@ func TestUpsertDataFailCommit(t *testing.T) {
 	mock.ExpectExec("INSERT .*").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertData(context.Background(), &fftypes.Data{ID: dataID}, true, true)
-	assert.Regexp(t, "FF10119", err.Error())
+	assert.Regexp(t, "FF10119", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -215,8 +220,8 @@ func TestGetDataByIDSelectFail(t *testing.T) {
 	s, mock := newMockProvider().init()
 	dataID := fftypes.NewUUID()
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
-	_, err := s.GetDataByID(context.Background(), dataID)
-	assert.Regexp(t, "FF10115", err.Error())
+	_, err := s.GetDataByID(context.Background(), dataID, false)
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -224,7 +229,7 @@ func TestGetDataByIDNotFound(t *testing.T) {
 	s, mock := newMockProvider().init()
 	dataID := fftypes.NewUUID()
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}))
-	msg, err := s.GetDataByID(context.Background(), dataID)
+	msg, err := s.GetDataByID(context.Background(), dataID, true)
 	assert.NoError(t, err)
 	assert.Nil(t, msg)
 	assert.NoError(t, mock.ExpectationsWereMet())
@@ -234,8 +239,8 @@ func TestGetDataByIDScanFail(t *testing.T) {
 	s, mock := newMockProvider().init()
 	dataID := fftypes.NewUUID()
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("only one"))
-	_, err := s.GetDataByID(context.Background(), dataID)
-	assert.Regexp(t, "FF10121", err.Error())
+	_, err := s.GetDataByID(context.Background(), dataID, true)
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -244,7 +249,7 @@ func TestGetDataQueryFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	f := database.DataQueryFactory.NewFilter(context.Background()).Eq("id", "")
 	_, err := s.GetData(context.Background(), f)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -252,7 +257,7 @@ func TestGetDataBuildQueryFail(t *testing.T) {
 	s, _ := newMockProvider().init()
 	f := database.DataQueryFactory.NewFilter(context.Background()).Eq("id", map[bool]bool{true: false})
 	_, err := s.GetData(context.Background(), f)
-	assert.Regexp(t, "FF10149.*id", err.Error())
+	assert.Regexp(t, "FF10149.*id", err)
 }
 
 func TestGetDataReadMessageFail(t *testing.T) {
@@ -260,7 +265,7 @@ func TestGetDataReadMessageFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("only one"))
 	f := database.DataQueryFactory.NewFilter(context.Background()).Eq("id", "")
 	_, err := s.GetData(context.Background(), f)
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -269,7 +274,7 @@ func TestGetDataRefsQueryFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	f := database.DataQueryFactory.NewFilter(context.Background()).Eq("id", "")
 	_, err := s.GetDataRefs(context.Background(), f)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -277,7 +282,7 @@ func TestGetDataRefsBuildQueryFail(t *testing.T) {
 	s, _ := newMockProvider().init()
 	f := database.DataQueryFactory.NewFilter(context.Background()).Eq("id", map[bool]bool{true: false})
 	_, err := s.GetDataRefs(context.Background(), f)
-	assert.Regexp(t, "FF10149.*id", err.Error())
+	assert.Regexp(t, "FF10149.*id", err)
 }
 
 func TestGetDataRefsReadMessageFail(t *testing.T) {
@@ -285,7 +290,7 @@ func TestGetDataRefsReadMessageFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("only one"))
 	f := database.DataQueryFactory.NewFilter(context.Background()).Eq("id", "")
 	_, err := s.GetDataRefs(context.Background(), f)
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -294,7 +299,7 @@ func TestDataUpdateBeginFail(t *testing.T) {
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	u := database.DataQueryFactory.NewUpdate(context.Background()).Set("id", "anything")
 	err := s.UpdateData(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 }
 
 func TestDataUpdateBuildQueryFail(t *testing.T) {
@@ -302,7 +307,7 @@ func TestDataUpdateBuildQueryFail(t *testing.T) {
 	mock.ExpectBegin()
 	u := database.DataQueryFactory.NewUpdate(context.Background()).Set("id", map[bool]bool{true: false})
 	err := s.UpdateData(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10149.*id", err.Error())
+	assert.Regexp(t, "FF10149.*id", err)
 }
 
 func TestDataUpdateFail(t *testing.T) {
@@ -312,5 +317,5 @@ func TestDataUpdateFail(t *testing.T) {
 	mock.ExpectRollback()
 	u := database.DataQueryFactory.NewUpdate(context.Background()).Set("id", fftypes.NewUUID())
 	err := s.UpdateData(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 }

--- a/internal/database/sqlcommon/data_sql_test.go
+++ b/internal/database/sqlcommon/data_sql_test.go
@@ -146,19 +146,6 @@ func TestDataE2EWithDB(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(dataRes))
 
-	// Check if we refer correctly to this data, we have it reported as available to a message
-	msg := &fftypes.Message{
-		Header: fftypes.MessageHeader{
-			ID:        fftypes.NewUUID(),
-			Namespace: dataUpdated.Namespace,
-		},
-		Data: fftypes.DataRefs{
-			{ID: dataUpdated.ID, Hash: dataUpdated.Hash},
-		},
-	}
-	dataAvailable, err := s.CheckDataAvailable(ctx, msg)
-	assert.NoError(t, err)
-	assert.True(t, dataAvailable)
 }
 
 func TestUpsertDataFailBegin(t *testing.T) {

--- a/internal/database/sqlcommon/datatype_sql_test.go
+++ b/internal/database/sqlcommon/datatype_sql_test.go
@@ -128,7 +128,7 @@ func TestUpsertDatatypeFailBegin(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertDatatype(context.Background(), &fftypes.Datatype{}, true)
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -139,7 +139,7 @@ func TestUpsertDatatypeFailSelect(t *testing.T) {
 	mock.ExpectRollback()
 	datatypeID := fftypes.NewUUID()
 	err := s.UpsertDatatype(context.Background(), &fftypes.Datatype{ID: datatypeID}, true)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -151,7 +151,7 @@ func TestUpsertDatatypeFailInsert(t *testing.T) {
 	mock.ExpectRollback()
 	datatypeID := fftypes.NewUUID()
 	err := s.UpsertDatatype(context.Background(), &fftypes.Datatype{ID: datatypeID}, true)
-	assert.Regexp(t, "FF10116", err.Error())
+	assert.Regexp(t, "FF10116", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -163,7 +163,7 @@ func TestUpsertDatatypeFailUpdate(t *testing.T) {
 	mock.ExpectExec("UPDATE .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	err := s.UpsertDatatype(context.Background(), &fftypes.Datatype{ID: datatypeID}, true)
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -175,7 +175,7 @@ func TestUpsertDatatypeFailCommit(t *testing.T) {
 	mock.ExpectExec("INSERT .*").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertDatatype(context.Background(), &fftypes.Datatype{ID: datatypeID}, true)
-	assert.Regexp(t, "FF10119", err.Error())
+	assert.Regexp(t, "FF10119", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -184,7 +184,7 @@ func TestGetDatatypeByIDSelectFail(t *testing.T) {
 	datatypeID := fftypes.NewUUID()
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	_, err := s.GetDatatypeByID(context.Background(), datatypeID)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -211,7 +211,7 @@ func TestGetDatatypeByIDScanFail(t *testing.T) {
 	datatypeID := fftypes.NewUUID()
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("only one"))
 	_, err := s.GetDatatypeByID(context.Background(), datatypeID)
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -220,7 +220,7 @@ func TestGetDatatypesQueryFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	f := database.DatatypeQueryFactory.NewFilter(context.Background()).Eq("id", "")
 	_, err := s.GetDatatypes(context.Background(), f)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -228,7 +228,7 @@ func TestGetDatatypesBuildQueryFail(t *testing.T) {
 	s, _ := newMockProvider().init()
 	f := database.DatatypeQueryFactory.NewFilter(context.Background()).Eq("id", map[bool]bool{true: false})
 	_, err := s.GetDatatypes(context.Background(), f)
-	assert.Regexp(t, "FF10149.*id", err.Error())
+	assert.Regexp(t, "FF10149.*id", err)
 }
 
 func TestGetDatatypesReadMessageFail(t *testing.T) {
@@ -236,7 +236,7 @@ func TestGetDatatypesReadMessageFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("only one"))
 	f := database.DatatypeQueryFactory.NewFilter(context.Background()).Eq("id", "")
 	_, err := s.GetDatatypes(context.Background(), f)
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -245,7 +245,7 @@ func TestDatatypeUpdateBeginFail(t *testing.T) {
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	u := database.DatatypeQueryFactory.NewUpdate(context.Background()).Set("id", "anything")
 	err := s.UpdateDatatype(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 }
 
 func TestDatatypeUpdateBuildQueryFail(t *testing.T) {
@@ -253,7 +253,7 @@ func TestDatatypeUpdateBuildQueryFail(t *testing.T) {
 	mock.ExpectBegin()
 	u := database.DatatypeQueryFactory.NewUpdate(context.Background()).Set("id", map[bool]bool{true: false})
 	err := s.UpdateDatatype(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10149.*id", err.Error())
+	assert.Regexp(t, "FF10149.*id", err)
 }
 
 func TestDatatypeUpdateFail(t *testing.T) {
@@ -263,5 +263,5 @@ func TestDatatypeUpdateFail(t *testing.T) {
 	mock.ExpectRollback()
 	u := database.DatatypeQueryFactory.NewUpdate(context.Background()).Set("id", fftypes.NewUUID())
 	err := s.UpdateDatatype(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 }

--- a/internal/database/sqlcommon/event_sql_test.go
+++ b/internal/database/sqlcommon/event_sql_test.go
@@ -124,7 +124,7 @@ func TestUpsertEventFailBegin(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertEvent(context.Background(), &fftypes.Event{}, true)
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -135,7 +135,7 @@ func TestUpsertEventFailSelect(t *testing.T) {
 	mock.ExpectRollback()
 	eventID := fftypes.NewUUID()
 	err := s.UpsertEvent(context.Background(), &fftypes.Event{ID: eventID}, true)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -147,7 +147,7 @@ func TestUpsertEventFailInsert(t *testing.T) {
 	mock.ExpectRollback()
 	eventID := fftypes.NewUUID()
 	err := s.UpsertEvent(context.Background(), &fftypes.Event{ID: eventID}, true)
-	assert.Regexp(t, "FF10116", err.Error())
+	assert.Regexp(t, "FF10116", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -159,7 +159,7 @@ func TestUpsertEventFailUpdate(t *testing.T) {
 	mock.ExpectExec("UPDATE .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	err := s.UpsertEvent(context.Background(), &fftypes.Event{ID: eventID}, true)
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -171,7 +171,7 @@ func TestUpsertEventFailCommit(t *testing.T) {
 	mock.ExpectExec("INSERT .*").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertEvent(context.Background(), &fftypes.Event{ID: eventID}, true)
-	assert.Regexp(t, "FF10119", err.Error())
+	assert.Regexp(t, "FF10119", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -180,7 +180,7 @@ func TestGetEventByIDSelectFail(t *testing.T) {
 	eventID := fftypes.NewUUID()
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	_, err := s.GetEventByID(context.Background(), eventID)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -199,7 +199,7 @@ func TestGetEventByIDScanFail(t *testing.T) {
 	eventID := fftypes.NewUUID()
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("only one"))
 	_, err := s.GetEventByID(context.Background(), eventID)
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -208,7 +208,7 @@ func TestGetEventsQueryFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	f := database.EventQueryFactory.NewFilter(context.Background()).Eq("id", "")
 	_, err := s.GetEvents(context.Background(), f)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -216,7 +216,7 @@ func TestGetEventsBuildQueryFail(t *testing.T) {
 	s, _ := newMockProvider().init()
 	f := database.EventQueryFactory.NewFilter(context.Background()).Eq("id", map[bool]bool{true: false})
 	_, err := s.GetEvents(context.Background(), f)
-	assert.Regexp(t, "FF10149.*id", err.Error())
+	assert.Regexp(t, "FF10149.*id", err)
 }
 
 func TestGettEventsReadMessageFail(t *testing.T) {
@@ -224,7 +224,7 @@ func TestGettEventsReadMessageFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("only one"))
 	f := database.EventQueryFactory.NewFilter(context.Background()).Eq("id", "")
 	_, err := s.GetEvents(context.Background(), f)
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -233,7 +233,7 @@ func TestEventUpdateBeginFail(t *testing.T) {
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	u := database.EventQueryFactory.NewUpdate(context.Background()).Set("id", "anything")
 	err := s.UpdateEvent(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 }
 
 func TestEventUpdateBuildQueryFail(t *testing.T) {
@@ -241,7 +241,7 @@ func TestEventUpdateBuildQueryFail(t *testing.T) {
 	mock.ExpectBegin()
 	u := database.EventQueryFactory.NewUpdate(context.Background()).Set("id", map[bool]bool{true: false})
 	err := s.UpdateEvent(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10149.*id", err.Error())
+	assert.Regexp(t, "FF10149.*id", err)
 }
 
 func TestEventUpdateFail(t *testing.T) {
@@ -251,5 +251,5 @@ func TestEventUpdateFail(t *testing.T) {
 	mock.ExpectRollback()
 	u := database.EventQueryFactory.NewUpdate(context.Background()).Set("id", fftypes.NewUUID())
 	err := s.UpdateEvent(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 }

--- a/internal/database/sqlcommon/filter_sql_test.go
+++ b/internal/database/sqlcommon/filter_sql_test.go
@@ -95,7 +95,7 @@ func TestSQLQueryFactoryFinalizeFail(t *testing.T) {
 	fb := database.MessageQueryFactory.NewFilter(context.Background())
 	sel := squirrel.Select("*").From("mytable")
 	_, err := s.filterSelect(context.Background(), "ns", sel, fb.Eq("namespace", map[bool]bool{true: false}), nil)
-	assert.Regexp(t, "FF10149.*namespace", err.Error())
+	assert.Regexp(t, "FF10149.*namespace", err)
 }
 
 func TestSQLQueryFactoryBadOp(t *testing.T) {
@@ -105,7 +105,7 @@ func TestSQLQueryFactoryBadOp(t *testing.T) {
 	_, err := s.filterSelectFinalized(context.Background(), "", sel, &database.FilterInfo{
 		Op: database.FilterOp("wrong"),
 	}, nil)
-	assert.Regexp(t, "FF10150.*wrong", err.Error())
+	assert.Regexp(t, "FF10150.*wrong", err)
 }
 
 func TestSQLQueryFactoryBadOpInOr(t *testing.T) {
@@ -118,7 +118,7 @@ func TestSQLQueryFactoryBadOpInOr(t *testing.T) {
 			{Op: database.FilterOp("wrong")},
 		},
 	}, nil)
-	assert.Regexp(t, "FF10150.*wrong", err.Error())
+	assert.Regexp(t, "FF10150.*wrong", err)
 }
 
 func TestSQLQueryFactoryBadOpInAnd(t *testing.T) {
@@ -131,5 +131,5 @@ func TestSQLQueryFactoryBadOpInAnd(t *testing.T) {
 			{Op: database.FilterOp("wrong")},
 		},
 	}, nil)
-	assert.Regexp(t, "FF10150.*wrong", err.Error())
+	assert.Regexp(t, "FF10150.*wrong", err)
 }

--- a/internal/database/sqlcommon/message_sql_test.go
+++ b/internal/database/sqlcommon/message_sql_test.go
@@ -201,7 +201,7 @@ func TestUpsertMessageFailBegin(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertMessage(context.Background(), &fftypes.Message{}, true, true)
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -212,7 +212,7 @@ func TestUpsertMessageFailSelect(t *testing.T) {
 	mock.ExpectRollback()
 	msgID := fftypes.NewUUID()
 	err := s.UpsertMessage(context.Background(), &fftypes.Message{Header: fftypes.MessageHeader{ID: msgID}}, true, true)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -224,7 +224,7 @@ func TestUpsertMessageFailInsert(t *testing.T) {
 	mock.ExpectRollback()
 	msgID := fftypes.NewUUID()
 	err := s.UpsertMessage(context.Background(), &fftypes.Message{Header: fftypes.MessageHeader{ID: msgID}}, true, true)
-	assert.Regexp(t, "FF10116", err.Error())
+	assert.Regexp(t, "FF10116", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -236,7 +236,7 @@ func TestUpsertMessageFailUpdate(t *testing.T) {
 	mock.ExpectExec("UPDATE .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	err := s.UpsertMessage(context.Background(), &fftypes.Message{Header: fftypes.MessageHeader{ID: msgID}}, true, true)
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -249,7 +249,7 @@ func TestUpsertMessageFailLoadRefs(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	err := s.UpsertMessage(context.Background(), &fftypes.Message{Header: fftypes.MessageHeader{ID: msgID}}, true, true)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -262,7 +262,7 @@ func TestUpsertMessageFailCommit(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"data_id"}))
 	mock.ExpectCommit().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertMessage(context.Background(), &fftypes.Message{Header: fftypes.MessageHeader{ID: msgID}}, true, true)
-	assert.Regexp(t, "FF10119", err.Error())
+	assert.Regexp(t, "FF10119", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -273,7 +273,7 @@ func TestGetMessageDataRefsScanFail(t *testing.T) {
 	tx, _ := s.db.Begin()
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"data_id"}).AddRow("not the uuid you are looking for"))
 	_, err := s.getMessageDataRefs(context.Background(), &txWrapper{sqlTX: tx}, msgID)
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -289,7 +289,7 @@ func TestUpdateMessageDataRefsNilID(t *testing.T) {
 		Header: fftypes.MessageHeader{ID: msgID},
 		Data:   []*fftypes.DataRef{{ID: nil}},
 	})
-	assert.Regexp(t, "FF10123", err.Error())
+	assert.Regexp(t, "FF10123", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -305,7 +305,7 @@ func TestUpdateMessageDataRefsNilHash(t *testing.T) {
 		Header: fftypes.MessageHeader{ID: msgID},
 		Data:   []*fftypes.DataRef{{ID: fftypes.NewUUID()}},
 	})
-	assert.Regexp(t, "FF10139", err.Error())
+	assert.Regexp(t, "FF10139", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -321,7 +321,7 @@ func TestUpdateMessageDataDeleteFail(t *testing.T) {
 	err := s.updateMessageDataRefs(context.Background(), &txWrapper{sqlTX: tx}, &fftypes.Message{
 		Header: fftypes.MessageHeader{ID: msgID},
 	})
-	assert.Regexp(t, "FF10118", err.Error())
+	assert.Regexp(t, "FF10118", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -338,7 +338,7 @@ func TestUpdateMessageDataAddFail(t *testing.T) {
 		Header: fftypes.MessageHeader{ID: msgID},
 		Data:   []*fftypes.DataRef{{ID: dataID, Hash: dataHash}},
 	})
-	assert.Regexp(t, "FF10116", err.Error())
+	assert.Regexp(t, "FF10116", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -363,7 +363,7 @@ func TestUpdateMessageDataSwitchIDxFail(t *testing.T) {
 		Header: fftypes.MessageHeader{ID: msgID},
 		Data:   []*fftypes.DataRef{{ID: dataID2, Hash: dataHash2}, {ID: dataID1, Hash: dataHash1}},
 	})
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -376,7 +376,7 @@ func TestLoadMessageDataRefsQueryFail(t *testing.T) {
 			Header: fftypes.MessageHeader{ID: msgID},
 		},
 	})
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -389,7 +389,7 @@ func TestLoadMessageDataRefsScanFail(t *testing.T) {
 			Header: fftypes.MessageHeader{ID: msgID},
 		},
 	})
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -409,7 +409,7 @@ func TestGetMessageByIDSelectFail(t *testing.T) {
 	msgID := fftypes.NewUUID()
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	_, err := s.GetMessageByID(context.Background(), msgID)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -428,7 +428,7 @@ func TestGetMessageByIDScanFail(t *testing.T) {
 	msgID := fftypes.NewUUID()
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("only one"))
 	_, err := s.GetMessageByID(context.Background(), msgID)
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -442,7 +442,7 @@ func TestGetMessageByIDLoadRefsFail(t *testing.T) {
 		AddRow(msgID.String(), nil, fftypes.MessageTypeBroadcast, "0x12345", 0, "ns1", "t1", "c1", nil, b32.String(), b32.String(), 0, "pin", nil, nil, 0))
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	_, err := s.GetMessageByID(context.Background(), msgID)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -450,7 +450,7 @@ func TestGetMessagesBuildQueryFail(t *testing.T) {
 	s, _ := newMockProvider().init()
 	f := database.MessageQueryFactory.NewFilter(context.Background()).Eq("id", map[bool]bool{true: false})
 	_, err := s.GetMessages(context.Background(), f)
-	assert.Regexp(t, "FF10149.*id", err.Error())
+	assert.Regexp(t, "FF10149.*id", err)
 }
 
 func TestGetMessagesQueryFail(t *testing.T) {
@@ -458,7 +458,7 @@ func TestGetMessagesQueryFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	f := database.MessageQueryFactory.NewFilter(context.Background()).Eq("id", "")
 	_, err := s.GetMessages(context.Background(), f)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -466,7 +466,7 @@ func TestGetMessagesForDataBadQuery(t *testing.T) {
 	s, mock := newMockProvider().init()
 	f := database.MessageQueryFactory.NewFilter(context.Background()).Eq("!wrong", "")
 	_, err := s.GetMessagesForData(context.Background(), fftypes.NewUUID(), f)
-	assert.Regexp(t, "FF10148", err.Error())
+	assert.Regexp(t, "FF10148", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -475,7 +475,7 @@ func TestGetMessagesReadMessageFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("only one"))
 	f := database.MessageQueryFactory.NewFilter(context.Background()).Eq("id", "")
 	_, err := s.GetMessages(context.Background(), f)
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -490,7 +490,7 @@ func TestGetMessagesLoadRefsFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	f := database.MessageQueryFactory.NewFilter(context.Background()).Gt("confirmed", "0")
 	_, err := s.GetMessages(context.Background(), f)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -498,7 +498,7 @@ func TestGetMessageRefsBuildQueryFail(t *testing.T) {
 	s, _ := newMockProvider().init()
 	f := database.MessageQueryFactory.NewFilter(context.Background()).Eq("id", map[bool]bool{true: false})
 	_, err := s.GetMessageRefs(context.Background(), f)
-	assert.Regexp(t, "FF10149.*id", err.Error())
+	assert.Regexp(t, "FF10149.*id", err)
 }
 
 func TestGetMessageRefsQueryFail(t *testing.T) {
@@ -506,7 +506,7 @@ func TestGetMessageRefsQueryFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	f := database.MessageQueryFactory.NewFilter(context.Background()).Eq("id", "")
 	_, err := s.GetMessageRefs(context.Background(), f)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -515,7 +515,7 @@ func TestGetMessageRefsReadMessageFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("only one"))
 	f := database.MessageQueryFactory.NewFilter(context.Background()).Eq("id", "")
 	_, err := s.GetMessageRefs(context.Background(), f)
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -524,7 +524,7 @@ func TestMessageUpdateBeginFail(t *testing.T) {
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	u := database.MessageQueryFactory.NewUpdate(context.Background()).Set("id", "anything")
 	err := s.UpdateMessage(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 }
 
 func TestMessageUpdateBuildQueryFail(t *testing.T) {
@@ -532,7 +532,7 @@ func TestMessageUpdateBuildQueryFail(t *testing.T) {
 	mock.ExpectBegin()
 	u := database.MessageQueryFactory.NewUpdate(context.Background()).Set("id", map[bool]bool{true: false})
 	err := s.UpdateMessage(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10149.*id", err.Error())
+	assert.Regexp(t, "FF10149.*id", err)
 }
 
 func TestMessagesUpdateBuildFilterFail(t *testing.T) {
@@ -541,7 +541,7 @@ func TestMessagesUpdateBuildFilterFail(t *testing.T) {
 	f := database.MessageQueryFactory.NewFilter(context.Background()).Eq("id", map[bool]bool{true: false})
 	u := database.MessageQueryFactory.NewUpdate(context.Background()).Set("type", fftypes.MessageTypeBroadcast)
 	err := s.UpdateMessages(context.Background(), f, u)
-	assert.Regexp(t, "FF10149.*id", err.Error())
+	assert.Regexp(t, "FF10149.*id", err)
 }
 
 func TestMessageUpdateFail(t *testing.T) {
@@ -551,7 +551,7 @@ func TestMessageUpdateFail(t *testing.T) {
 	mock.ExpectRollback()
 	u := database.MessageQueryFactory.NewUpdate(context.Background()).Set("group", fftypes.NewUUID())
 	err := s.UpdateMessage(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 }
 
 func TestCheckDataAvailableFalseBadMessage(t *testing.T) {
@@ -600,7 +600,7 @@ func TestCheckDataAvailableDatabaseError(t *testing.T) {
 			{ID: fftypes.NewUUID(), Hash: fftypes.NewRandB32()},
 		},
 	})
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.False(t, ok)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
@@ -617,7 +617,7 @@ func TestCheckDataAvailableScanError(t *testing.T) {
 			{ID: fftypes.NewUUID(), Hash: fftypes.NewRandB32()},
 		},
 	})
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.False(t, ok)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/database/sqlcommon/namespace_sql_test.go
+++ b/internal/database/sqlcommon/namespace_sql_test.go
@@ -113,7 +113,7 @@ func TestUpsertNamespaceFailBegin(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertNamespace(context.Background(), &fftypes.Namespace{}, true)
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -123,7 +123,7 @@ func TestUpsertNamespaceFailSelect(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	err := s.UpsertNamespace(context.Background(), &fftypes.Namespace{Name: "name1"}, true)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -134,7 +134,7 @@ func TestUpsertNamespaceFailInsert(t *testing.T) {
 	mock.ExpectExec("INSERT .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	err := s.UpsertNamespace(context.Background(), &fftypes.Namespace{Name: "name1"}, true)
-	assert.Regexp(t, "FF10116", err.Error())
+	assert.Regexp(t, "FF10116", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -146,7 +146,7 @@ func TestUpsertNamespaceFailUpdate(t *testing.T) {
 	mock.ExpectExec("UPDATE .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	err := s.UpsertNamespace(context.Background(), &fftypes.Namespace{Name: "name1"}, true)
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -157,7 +157,7 @@ func TestUpsertNamespaceFailCommit(t *testing.T) {
 	mock.ExpectExec("INSERT .*").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertNamespace(context.Background(), &fftypes.Namespace{Name: "name1"}, true)
-	assert.Regexp(t, "FF10119", err.Error())
+	assert.Regexp(t, "FF10119", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -165,7 +165,7 @@ func TestGetNamespaceByIDSelectFail(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	_, err := s.GetNamespace(context.Background(), "name1")
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -182,7 +182,7 @@ func TestGetNamespaceByIDScanFail(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"ntype"}).AddRow("only one"))
 	_, err := s.GetNamespace(context.Background(), "name1")
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -191,7 +191,7 @@ func TestGetNamespaceQueryFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	f := database.NamespaceQueryFactory.NewFilter(context.Background()).Eq("type", "")
 	_, err := s.GetNamespaces(context.Background(), f)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -199,7 +199,7 @@ func TestGetNamespaceBuildQueryFail(t *testing.T) {
 	s, _ := newMockProvider().init()
 	f := database.NamespaceQueryFactory.NewFilter(context.Background()).Eq("type", map[bool]bool{true: false})
 	_, err := s.GetNamespaces(context.Background(), f)
-	assert.Regexp(t, "FF10149.*type", err.Error())
+	assert.Regexp(t, "FF10149.*type", err)
 }
 
 func TestGetNamespaceReadMessageFail(t *testing.T) {
@@ -207,7 +207,7 @@ func TestGetNamespaceReadMessageFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"ntype"}).AddRow("only one"))
 	f := database.NamespaceQueryFactory.NewFilter(context.Background()).Eq("type", "")
 	_, err := s.GetNamespaces(context.Background(), f)
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -216,7 +216,7 @@ func TestNamespaceUpdateBeginFail(t *testing.T) {
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	u := database.NamespaceQueryFactory.NewUpdate(context.Background()).Set("name", "anything")
 	err := s.UpdateNamespace(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 }
 
 func TestNamespaceUpdateBuildQueryFail(t *testing.T) {
@@ -224,7 +224,7 @@ func TestNamespaceUpdateBuildQueryFail(t *testing.T) {
 	mock.ExpectBegin()
 	u := database.NamespaceQueryFactory.NewUpdate(context.Background()).Set("name", map[bool]bool{true: false})
 	err := s.UpdateNamespace(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10149.*name", err.Error())
+	assert.Regexp(t, "FF10149.*name", err)
 }
 
 func TestNamespaceUpdateFail(t *testing.T) {
@@ -234,5 +234,5 @@ func TestNamespaceUpdateFail(t *testing.T) {
 	mock.ExpectRollback()
 	u := database.NamespaceQueryFactory.NewUpdate(context.Background()).Set("name", fftypes.NewUUID())
 	err := s.UpdateNamespace(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 }

--- a/internal/database/sqlcommon/offset_sql_test.go
+++ b/internal/database/sqlcommon/offset_sql_test.go
@@ -127,7 +127,7 @@ func TestUpsertOffsetFailBegin(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertOffset(context.Background(), &fftypes.Offset{}, true)
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -137,7 +137,7 @@ func TestUpsertOffsetFailSelect(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	err := s.UpsertOffset(context.Background(), &fftypes.Offset{Name: "name1"}, true)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -148,7 +148,7 @@ func TestUpsertOffsetFailInsert(t *testing.T) {
 	mock.ExpectExec("INSERT .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	err := s.UpsertOffset(context.Background(), &fftypes.Offset{Name: "name1"}, true)
-	assert.Regexp(t, "FF10116", err.Error())
+	assert.Regexp(t, "FF10116", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -160,7 +160,7 @@ func TestUpsertOffsetFailUpdate(t *testing.T) {
 	mock.ExpectExec("UPDATE .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	err := s.UpsertOffset(context.Background(), &fftypes.Offset{Name: "name1"}, true)
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -171,7 +171,7 @@ func TestUpsertOffsetFailCommit(t *testing.T) {
 	mock.ExpectExec("INSERT .*").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertOffset(context.Background(), &fftypes.Offset{Name: "name1"}, true)
-	assert.Regexp(t, "FF10119", err.Error())
+	assert.Regexp(t, "FF10119", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -179,7 +179,7 @@ func TestGetOffsetByIDSelectFail(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	_, err := s.GetOffset(context.Background(), fftypes.OffsetTypeBatch, "ns1", "name1")
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -196,7 +196,7 @@ func TestGetOffsetByIDScanFail(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"otype"}).AddRow("only one"))
 	_, err := s.GetOffset(context.Background(), fftypes.OffsetTypeBatch, "ns1", "name1")
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -205,7 +205,7 @@ func TestGetOffsetQueryFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	f := database.OffsetQueryFactory.NewFilter(context.Background()).Eq("type", "")
 	_, err := s.GetOffsets(context.Background(), f)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -213,7 +213,7 @@ func TestGetOffsetBuildQueryFail(t *testing.T) {
 	s, _ := newMockProvider().init()
 	f := database.OffsetQueryFactory.NewFilter(context.Background()).Eq("type", map[bool]bool{true: false})
 	_, err := s.GetOffsets(context.Background(), f)
-	assert.Regexp(t, "FF10149.*type", err.Error())
+	assert.Regexp(t, "FF10149.*type", err)
 }
 
 func TestGetOffsetReadMessageFail(t *testing.T) {
@@ -221,7 +221,7 @@ func TestGetOffsetReadMessageFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"otype"}).AddRow("only one"))
 	f := database.OffsetQueryFactory.NewFilter(context.Background()).Eq("type", "")
 	_, err := s.GetOffsets(context.Background(), f)
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -230,7 +230,7 @@ func TestOffsetUpdateBeginFail(t *testing.T) {
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	u := database.OffsetQueryFactory.NewUpdate(context.Background()).Set("name", "anything")
 	err := s.UpdateOffset(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 }
 
 func TestOffsetUpdateBuildQueryFail(t *testing.T) {
@@ -238,7 +238,7 @@ func TestOffsetUpdateBuildQueryFail(t *testing.T) {
 	mock.ExpectBegin()
 	u := database.OffsetQueryFactory.NewUpdate(context.Background()).Set("name", map[bool]bool{true: false})
 	err := s.UpdateOffset(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10149.*name", err.Error())
+	assert.Regexp(t, "FF10149.*name", err)
 }
 
 func TestOffsetUpdateFail(t *testing.T) {
@@ -248,14 +248,14 @@ func TestOffsetUpdateFail(t *testing.T) {
 	mock.ExpectRollback()
 	u := database.OffsetQueryFactory.NewUpdate(context.Background()).Set("name", fftypes.NewUUID())
 	err := s.UpdateOffset(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 }
 
 func TestOffsetDeleteBeginFail(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	err := s.DeleteOffset(context.Background(), fftypes.OffsetTypeSubscription, "ns1", "sub1")
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 }
 
 func TestOffsetDeleteFail(t *testing.T) {
@@ -264,5 +264,5 @@ func TestOffsetDeleteFail(t *testing.T) {
 	mock.ExpectExec("DELETE .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	err := s.DeleteOffset(context.Background(), fftypes.OffsetTypeSubscription, "ns1", "sub1")
-	assert.Regexp(t, "FF10118", err.Error())
+	assert.Regexp(t, "FF10118", err)
 }

--- a/internal/database/sqlcommon/operation_sql_test.go
+++ b/internal/database/sqlcommon/operation_sql_test.go
@@ -140,7 +140,7 @@ func TestUpsertOperationFailBegin(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertOperation(context.Background(), &fftypes.Operation{}, true)
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -151,7 +151,7 @@ func TestUpsertOperationFailSelect(t *testing.T) {
 	mock.ExpectRollback()
 	operationID := fftypes.NewUUID()
 	err := s.UpsertOperation(context.Background(), &fftypes.Operation{ID: operationID}, true)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -163,7 +163,7 @@ func TestUpsertOperationFailInsert(t *testing.T) {
 	mock.ExpectRollback()
 	operationID := fftypes.NewUUID()
 	err := s.UpsertOperation(context.Background(), &fftypes.Operation{ID: operationID}, true)
-	assert.Regexp(t, "FF10116", err.Error())
+	assert.Regexp(t, "FF10116", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -175,7 +175,7 @@ func TestUpsertOperationFailUpdate(t *testing.T) {
 	mock.ExpectExec("UPDATE .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	err := s.UpsertOperation(context.Background(), &fftypes.Operation{ID: operationID}, true)
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -187,7 +187,7 @@ func TestUpsertOperationFailCommit(t *testing.T) {
 	mock.ExpectExec("INSERT .*").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertOperation(context.Background(), &fftypes.Operation{ID: operationID}, true)
-	assert.Regexp(t, "FF10119", err.Error())
+	assert.Regexp(t, "FF10119", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -196,7 +196,7 @@ func TestGetOperationByIDSelectFail(t *testing.T) {
 	operationID := fftypes.NewUUID()
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	_, err := s.GetOperationByID(context.Background(), operationID)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -215,7 +215,7 @@ func TestGetOperationByIDScanFail(t *testing.T) {
 	operationID := fftypes.NewUUID()
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("only one"))
 	_, err := s.GetOperationByID(context.Background(), operationID)
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -224,7 +224,7 @@ func TestGetOperationsQueryFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	f := database.OperationQueryFactory.NewFilter(context.Background()).Eq("id", "")
 	_, err := s.GetOperations(context.Background(), f)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -232,7 +232,7 @@ func TestGetOperationsBuildQueryFail(t *testing.T) {
 	s, _ := newMockProvider().init()
 	f := database.OperationQueryFactory.NewFilter(context.Background()).Eq("id", map[bool]bool{true: false})
 	_, err := s.GetOperations(context.Background(), f)
-	assert.Regexp(t, "FF10149.*id", err.Error())
+	assert.Regexp(t, "FF10149.*id", err)
 }
 
 func TestGettOperationsReadMessageFail(t *testing.T) {
@@ -240,7 +240,7 @@ func TestGettOperationsReadMessageFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("only one"))
 	f := database.OperationQueryFactory.NewFilter(context.Background()).Eq("id", "")
 	_, err := s.GetOperations(context.Background(), f)
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -250,7 +250,7 @@ func TestOperationUpdateBeginFail(t *testing.T) {
 	f := database.OperationQueryFactory.NewFilter(context.Background()).Eq("id", fftypes.NewUUID())
 	u := database.OperationQueryFactory.NewUpdate(context.Background()).Set("id", fftypes.NewUUID())
 	err := s.UpdateOperations(context.Background(), f, u)
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 }
 
 func TestOperationUpdateBuildQueryFail(t *testing.T) {
@@ -259,7 +259,7 @@ func TestOperationUpdateBuildQueryFail(t *testing.T) {
 	f := database.OperationQueryFactory.NewFilter(context.Background()).Eq("id", fftypes.NewUUID())
 	u := database.OperationQueryFactory.NewUpdate(context.Background()).Set("id", map[bool]bool{true: false})
 	err := s.UpdateOperations(context.Background(), f, u)
-	assert.Regexp(t, "FF10149.*id", err.Error())
+	assert.Regexp(t, "FF10149.*id", err)
 }
 
 func TestOperationUpdateBuildFilterFail(t *testing.T) {
@@ -268,7 +268,7 @@ func TestOperationUpdateBuildFilterFail(t *testing.T) {
 	f := database.OperationQueryFactory.NewFilter(context.Background()).Eq("id", map[bool]bool{true: false})
 	u := database.OperationQueryFactory.NewUpdate(context.Background()).Set("id", fftypes.NewUUID())
 	err := s.UpdateOperations(context.Background(), f, u)
-	assert.Regexp(t, "FF10149.*id", err.Error())
+	assert.Regexp(t, "FF10149.*id", err)
 }
 
 func TestOperationUpdateFail(t *testing.T) {
@@ -279,5 +279,5 @@ func TestOperationUpdateFail(t *testing.T) {
 	f := database.OperationQueryFactory.NewFilter(context.Background()).Eq("id", fftypes.NewUUID())
 	u := database.OperationQueryFactory.NewUpdate(context.Background()).Set("id", fftypes.NewUUID())
 	err := s.UpdateOperations(context.Background(), f, u)
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 }

--- a/internal/database/sqlcommon/sqlcommon_test.go
+++ b/internal/database/sqlcommon/sqlcommon_test.go
@@ -37,14 +37,14 @@ func TestInitSQLCommon(t *testing.T) {
 func TestInitSQLCommonMissingOptions(t *testing.T) {
 	s := &SQLCommon{}
 	err := s.Init(context.Background(), nil, nil, nil, nil)
-	assert.Regexp(t, "FF10112", err.Error())
+	assert.Regexp(t, "FF10112", err)
 }
 
 func TestInitSQLCommonOpenFailed(t *testing.T) {
 	mp := newMockProvider()
 	mp.openError = fmt.Errorf("pop")
 	err := mp.SQLCommon.Init(context.Background(), mp, mp.prefix, mp.callbacks, mp.capabilities)
-	assert.Regexp(t, "FF10112.*pop", err.Error())
+	assert.Regexp(t, "FF10112.*pop", err)
 }
 
 func TestInitSQLCommonMigrationOpenFailed(t *testing.T) {
@@ -52,13 +52,13 @@ func TestInitSQLCommonMigrationOpenFailed(t *testing.T) {
 	mp.prefix.Set(SQLConfMigrationsAuto, true)
 	mp.getMigrationDriverError = fmt.Errorf("pop")
 	err := mp.SQLCommon.Init(context.Background(), mp, mp.prefix, mp.callbacks, mp.capabilities)
-	assert.Regexp(t, "FF10163.*pop", err.Error())
+	assert.Regexp(t, "FF10163.*pop", err)
 }
 
 func TestQueryTxBadSQL(t *testing.T) {
 	tp := newQLTestProvider(t)
 	_, err := tp.queryTx(context.Background(), nil, sq.SelectBuilder{})
-	assert.Regexp(t, "FF10113", err.Error())
+	assert.Regexp(t, "FF10113", err)
 }
 
 func TestInsertTxPostgreSQLReturnedSyntax(t *testing.T) {
@@ -83,25 +83,25 @@ func TestInsertTxPostgreSQLReturnedSyntaxFail(t *testing.T) {
 	s.fakePSQLInsert = true
 	sb := sq.Insert("table").Columns("col1").Values(("val1"))
 	_, err = s.insertTx(ctx, tx, sb)
-	assert.Regexp(t, "FF10116", err.Error())
+	assert.Regexp(t, "FF10116", err)
 }
 
 func TestInsertTxBadSQL(t *testing.T) {
 	s, _ := newMockProvider().init()
 	_, err := s.insertTx(context.Background(), nil, sq.InsertBuilder{})
-	assert.Regexp(t, "FF10113", err.Error())
+	assert.Regexp(t, "FF10113", err)
 }
 
 func TestUpdateTxBadSQL(t *testing.T) {
 	s, _ := newMockProvider().init()
 	err := s.updateTx(context.Background(), nil, sq.UpdateBuilder{})
-	assert.Regexp(t, "FF10113", err.Error())
+	assert.Regexp(t, "FF10113", err)
 }
 
 func TestDeleteTxBadSQL(t *testing.T) {
 	s, _ := newMockProvider().init()
 	err := s.deleteTx(context.Background(), nil, sq.DeleteBuilder{})
-	assert.Regexp(t, "FF10113", err.Error())
+	assert.Regexp(t, "FF10113", err)
 }
 
 func TestDeleteTxZeroRowsAffected(t *testing.T) {
@@ -113,7 +113,7 @@ func TestDeleteTxZeroRowsAffected(t *testing.T) {
 	s.fakePSQLInsert = true
 	sb := sq.Delete("table")
 	err = s.deleteTx(ctx, tx, sb)
-	assert.Regexp(t, "FF10109", err.Error())
+	assert.Regexp(t, "FF10109", err)
 }
 
 func TestRunAsGroup(t *testing.T) {
@@ -158,7 +158,7 @@ func TestRunAsGroupBeginFail(t *testing.T) {
 		return
 	})
 	assert.NoError(t, mock.ExpectationsWereMet())
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 }
 
 func TestRunAsGroupFunctionFails(t *testing.T) {
@@ -177,7 +177,7 @@ func TestRunAsGroupFunctionFails(t *testing.T) {
 		return fmt.Errorf("pop")
 	})
 	assert.NoError(t, mock.ExpectationsWereMet())
-	assert.Regexp(t, "pop", err.Error())
+	assert.Regexp(t, "pop", err)
 }
 
 func TestRunAsGroupCommitFail(t *testing.T) {
@@ -188,7 +188,7 @@ func TestRunAsGroupCommitFail(t *testing.T) {
 		return
 	})
 	assert.NoError(t, mock.ExpectationsWereMet())
-	assert.Regexp(t, "FF10119", err.Error())
+	assert.Regexp(t, "FF10119", err)
 }
 
 func TestRollbackFail(t *testing.T) {

--- a/internal/database/sqlcommon/subscription_sql_test.go
+++ b/internal/database/sqlcommon/subscription_sql_test.go
@@ -140,7 +140,7 @@ func TestUpsertSubscriptionFailBegin(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertSubscription(context.Background(), &fftypes.Subscription{}, true)
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -150,7 +150,7 @@ func TestUpsertSubscriptionFailSelect(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	err := s.UpsertSubscription(context.Background(), &fftypes.Subscription{SubscriptionRef: fftypes.SubscriptionRef{Name: "name1"}}, true)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -161,7 +161,7 @@ func TestUpsertSubscriptionFailInsert(t *testing.T) {
 	mock.ExpectExec("INSERT .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	err := s.UpsertSubscription(context.Background(), &fftypes.Subscription{SubscriptionRef: fftypes.SubscriptionRef{Name: "name1"}}, true)
-	assert.Regexp(t, "FF10116", err.Error())
+	assert.Regexp(t, "FF10116", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -173,7 +173,7 @@ func TestUpsertSubscriptionFailUpdate(t *testing.T) {
 	mock.ExpectExec("UPDATE .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	err := s.UpsertSubscription(context.Background(), &fftypes.Subscription{SubscriptionRef: fftypes.SubscriptionRef{Name: "name1"}}, true)
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -184,7 +184,7 @@ func TestUpsertSubscriptionFailCommit(t *testing.T) {
 	mock.ExpectExec("INSERT .*").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertSubscription(context.Background(), &fftypes.Subscription{SubscriptionRef: fftypes.SubscriptionRef{Name: "name1"}}, true)
-	assert.Regexp(t, "FF10119", err.Error())
+	assert.Regexp(t, "FF10119", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -192,7 +192,7 @@ func TestGetSubscriptionByIDSelectFail(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	_, err := s.GetSubscriptionByName(context.Background(), "ns1", "name1")
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -209,7 +209,7 @@ func TestGetSubscriptionByIDScanFail(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"namespace"}).AddRow("only one"))
 	_, err := s.GetSubscriptionByName(context.Background(), "ns1", "name1")
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -218,7 +218,7 @@ func TestGetSubscriptionQueryFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	f := database.SubscriptionQueryFactory.NewFilter(context.Background()).Eq("name", "")
 	_, err := s.GetSubscriptions(context.Background(), f)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -226,7 +226,7 @@ func TestGetSubscriptionBuildQueryFail(t *testing.T) {
 	s, _ := newMockProvider().init()
 	f := database.SubscriptionQueryFactory.NewFilter(context.Background()).Eq("name", map[bool]bool{true: false})
 	_, err := s.GetSubscriptions(context.Background(), f)
-	assert.Regexp(t, "FF10149.*type", err.Error())
+	assert.Regexp(t, "FF10149.*type", err)
 }
 
 func TestGetSubscriptionReadMessageFail(t *testing.T) {
@@ -234,7 +234,7 @@ func TestGetSubscriptionReadMessageFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"ntype"}).AddRow("only one"))
 	f := database.SubscriptionQueryFactory.NewFilter(context.Background()).Eq("name", "")
 	_, err := s.GetSubscriptions(context.Background(), f)
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -243,7 +243,7 @@ func TestSubscriptionUpdateBeginFail(t *testing.T) {
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	u := database.SubscriptionQueryFactory.NewUpdate(context.Background()).Set("name", "anything")
 	err := s.UpdateSubscription(context.Background(), "ns1", "name1", u)
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 }
 
 func TestSubscriptionUpdateBuildQueryFail(t *testing.T) {
@@ -251,7 +251,7 @@ func TestSubscriptionUpdateBuildQueryFail(t *testing.T) {
 	mock.ExpectBegin()
 	u := database.SubscriptionQueryFactory.NewUpdate(context.Background()).Set("name", map[bool]bool{true: false})
 	err := s.UpdateSubscription(context.Background(), "ns1", "name1", u)
-	assert.Regexp(t, "FF10149.*name", err.Error())
+	assert.Regexp(t, "FF10149.*name", err)
 }
 
 func TestSubscriptionUpdateFail(t *testing.T) {
@@ -261,14 +261,14 @@ func TestSubscriptionUpdateFail(t *testing.T) {
 	mock.ExpectRollback()
 	u := database.SubscriptionQueryFactory.NewUpdate(context.Background()).Set("name", fftypes.NewUUID())
 	err := s.UpdateSubscription(context.Background(), "ns1", "name1", u)
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 }
 
 func TestSubscriptionDeleteBeginFail(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	err := s.DeleteSubscriptionByID(context.Background(), fftypes.NewUUID())
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 }
 
 func TestSubscriptionDeleteFail(t *testing.T) {
@@ -276,5 +276,5 @@ func TestSubscriptionDeleteFail(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectExec("DELETE .*").WillReturnError(fmt.Errorf("pop"))
 	err := s.DeleteSubscriptionByID(context.Background(), fftypes.NewUUID())
-	assert.Regexp(t, "FF10118", err.Error())
+	assert.Regexp(t, "FF10118", err)
 }

--- a/internal/database/sqlcommon/transaction_sql_test.go
+++ b/internal/database/sqlcommon/transaction_sql_test.go
@@ -140,7 +140,7 @@ func TestUpsertTransactionFailBegin(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertTransaction(context.Background(), &fftypes.Transaction{}, true, true)
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -151,7 +151,7 @@ func TestUpsertTransactionFailSelect(t *testing.T) {
 	mock.ExpectRollback()
 	transactionID := fftypes.NewUUID()
 	err := s.UpsertTransaction(context.Background(), &fftypes.Transaction{ID: transactionID}, true, true)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -163,7 +163,7 @@ func TestUpsertTransactionFailInsert(t *testing.T) {
 	mock.ExpectRollback()
 	transactionID := fftypes.NewUUID()
 	err := s.UpsertTransaction(context.Background(), &fftypes.Transaction{ID: transactionID}, true, true)
-	assert.Regexp(t, "FF10116", err.Error())
+	assert.Regexp(t, "FF10116", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -175,7 +175,7 @@ func TestUpsertTransactionFailUpdate(t *testing.T) {
 	mock.ExpectExec("UPDATE .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	err := s.UpsertTransaction(context.Background(), &fftypes.Transaction{ID: transactionID}, true, true)
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -187,7 +187,7 @@ func TestUpsertTransactionFailCommit(t *testing.T) {
 	mock.ExpectExec("INSERT .*").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit().WillReturnError(fmt.Errorf("pop"))
 	err := s.UpsertTransaction(context.Background(), &fftypes.Transaction{ID: transactionID}, true, true)
-	assert.Regexp(t, "FF10119", err.Error())
+	assert.Regexp(t, "FF10119", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -196,7 +196,7 @@ func TestGetTransactionByIDSelectFail(t *testing.T) {
 	transactionID := fftypes.NewUUID()
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	_, err := s.GetTransactionByID(context.Background(), transactionID)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -215,7 +215,7 @@ func TestGetTransactionByIDScanFail(t *testing.T) {
 	transactionID := fftypes.NewUUID()
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("only one"))
 	_, err := s.GetTransactionByID(context.Background(), transactionID)
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -224,7 +224,7 @@ func TestGetTransactionsQueryFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
 	f := database.TransactionQueryFactory.NewFilter(context.Background()).Eq("id", "")
 	_, err := s.GetTransactions(context.Background(), f)
-	assert.Regexp(t, "FF10115", err.Error())
+	assert.Regexp(t, "FF10115", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -232,7 +232,7 @@ func TestGetTransactionsBuildQueryFail(t *testing.T) {
 	s, _ := newMockProvider().init()
 	f := database.TransactionQueryFactory.NewFilter(context.Background()).Eq("id", map[bool]bool{true: false})
 	_, err := s.GetTransactions(context.Background(), f)
-	assert.Regexp(t, "FF10149.*id", err.Error())
+	assert.Regexp(t, "FF10149.*id", err)
 }
 
 func TestGettTransactionsReadMessageFail(t *testing.T) {
@@ -240,7 +240,7 @@ func TestGettTransactionsReadMessageFail(t *testing.T) {
 	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow("only one"))
 	f := database.TransactionQueryFactory.NewFilter(context.Background()).Eq("id", "")
 	_, err := s.GetTransactions(context.Background(), f)
-	assert.Regexp(t, "FF10121", err.Error())
+	assert.Regexp(t, "FF10121", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -249,7 +249,7 @@ func TestTransactionUpdateBeginFail(t *testing.T) {
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
 	u := database.TransactionQueryFactory.NewUpdate(context.Background()).Set("id", "anything")
 	err := s.UpdateTransaction(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10114", err.Error())
+	assert.Regexp(t, "FF10114", err)
 }
 
 func TestTransactionUpdateBuildQueryFail(t *testing.T) {
@@ -257,7 +257,7 @@ func TestTransactionUpdateBuildQueryFail(t *testing.T) {
 	mock.ExpectBegin()
 	u := database.TransactionQueryFactory.NewUpdate(context.Background()).Set("id", map[bool]bool{true: false})
 	err := s.UpdateTransaction(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10149.*id", err.Error())
+	assert.Regexp(t, "FF10149.*id", err)
 }
 
 func TestTransactionUpdateFail(t *testing.T) {
@@ -267,5 +267,5 @@ func TestTransactionUpdateFail(t *testing.T) {
 	mock.ExpectRollback()
 	u := database.TransactionQueryFactory.NewUpdate(context.Background()).Set("id", fftypes.NewUUID())
 	err := s.UpdateTransaction(context.Background(), fftypes.NewUUID(), u)
-	assert.Regexp(t, "FF10117", err.Error())
+	assert.Regexp(t, "FF10117", err)
 }

--- a/internal/events/aggregator.go
+++ b/internal/events/aggregator.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/kaleido-io/firefly/internal/broadcast"
 	"github.com/kaleido-io/firefly/internal/config"
+	"github.com/kaleido-io/firefly/internal/data"
 	"github.com/kaleido-io/firefly/internal/log"
 	"github.com/kaleido-io/firefly/internal/retry"
 	"github.com/kaleido-io/firefly/pkg/database"
@@ -63,14 +64,16 @@ type aggregator struct {
 	ctx         context.Context
 	database    database.Plugin
 	broadcast   broadcast.Manager
+	data        data.Manager
 	eventPoller *eventPoller
 }
 
-func newAggregator(ctx context.Context, di database.Plugin, bm broadcast.Manager, en *eventNotifier) *aggregator {
+func newAggregator(ctx context.Context, di database.Plugin, bm broadcast.Manager, dm data.Manager, en *eventNotifier) *aggregator {
 	ag := &aggregator{
 		ctx:       log.WithLogField(ctx, "role", "aggregator"),
 		database:  di,
 		broadcast: bm,
+		data:      dm,
 	}
 	firstEvent := fftypes.SubOptsFirstEvent(config.GetString(config.EventAggregatorFirstEvent))
 	ag.eventPoller = newEventPoller(ctx, di, en, &eventPollerConf{

--- a/internal/events/aggregator_test.go
+++ b/internal/events/aggregator_test.go
@@ -705,7 +705,7 @@ func TestCheckMessageCompleteSystemHandlerFail(t *testing.T) {
 	ev := &fftypes.Event{ID: fftypes.NewUUID(), Type: fftypes.EventTypeMessageSequencedBroadcast, Reference: msg.Header.ID}
 	mdm.On("GetMessageData", mock.Anything, msg, true).Return([]*fftypes.Data{}, true, nil)
 	mdi.On("GetBlockedByContext", mock.Anything, mock.Anything, mock.Anything, (*fftypes.UUID)(nil)).Return(nil, nil)
-	mbm.On("HandleSystemBroadcast", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
+	mbm.On("HandleSystemBroadcast", mock.Anything, mock.Anything, mock.Anything).Return(false, fmt.Errorf("pop"))
 	repoll, err := ag.checkMessageComplete(context.Background(), msg, eventsByRef{}, ev)
 	assert.False(t, repoll)
 	assert.EqualError(t, err, "pop")

--- a/internal/events/event_dispatcher_test.go
+++ b/internal/events/event_dispatcher_test.go
@@ -496,7 +496,7 @@ func TestBufferedDeliveryClosedContext(t *testing.T) {
 		{ID: fftypes.NewUUID()},
 	})
 	assert.False(t, repoll)
-	assert.Regexp(t, "FF10182", err.Error())
+	assert.Regexp(t, "FF10182", err)
 
 }
 

--- a/internal/events/event_manager.go
+++ b/internal/events/event_manager.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/kaleido-io/firefly/internal/broadcast"
 	"github.com/kaleido-io/firefly/internal/config"
+	"github.com/kaleido-io/firefly/internal/data"
 	"github.com/kaleido-io/firefly/internal/i18n"
 	"github.com/kaleido-io/firefly/internal/log"
 	"github.com/kaleido-io/firefly/internal/retry"
@@ -48,6 +49,7 @@ type eventManager struct {
 	publicstorage    publicstorage.Plugin
 	database         database.Plugin
 	broadcast        broadcast.Manager
+	data             data.Manager
 	subManager       *subscriptionManager
 	retry            retry.Retry
 	aggregator       *aggregator
@@ -55,7 +57,7 @@ type eventManager struct {
 	defaultTransport string
 }
 
-func NewEventManager(ctx context.Context, pi publicstorage.Plugin, di database.Plugin, bm broadcast.Manager) (EventManager, error) {
+func NewEventManager(ctx context.Context, pi publicstorage.Plugin, di database.Plugin, bm broadcast.Manager, dm data.Manager) (EventManager, error) {
 	if pi == nil || di == nil {
 		return nil, i18n.NewError(ctx, i18n.MsgInitializationNilDepError)
 	}
@@ -65,6 +67,7 @@ func NewEventManager(ctx context.Context, pi publicstorage.Plugin, di database.P
 		publicstorage: pi,
 		database:      di,
 		broadcast:     bm,
+		data:          dm,
 		retry: retry.Retry{
 			InitialDelay: config.GetDuration(config.EventAggregatorRetryInitDelay),
 			MaximumDelay: config.GetDuration(config.EventAggregatorRetryMaxDelay),
@@ -72,7 +75,7 @@ func NewEventManager(ctx context.Context, pi publicstorage.Plugin, di database.P
 		},
 		defaultTransport: config.GetString(config.EventTransportsDefault),
 		eventNotifier:    en,
-		aggregator:       newAggregator(ctx, di, bm, en),
+		aggregator:       newAggregator(ctx, di, bm, dm, en),
 	}
 
 	var err error

--- a/internal/events/event_manager_test.go
+++ b/internal/events/event_manager_test.go
@@ -117,7 +117,7 @@ func TestCreateDurableSubscriptionBadSub(t *testing.T) {
 	em, cancel := newTestEventManager(t)
 	defer cancel()
 	err := em.CreateDurableSubscription(em.ctx, &fftypes.Subscription{})
-	assert.Regexp(t, "FF10189", err.Error())
+	assert.Regexp(t, "FF10189", err)
 }
 
 func TestCreateDurableSubscriptionDupName(t *testing.T) {
@@ -133,7 +133,7 @@ func TestCreateDurableSubscriptionDupName(t *testing.T) {
 	}
 	mdi.On("GetSubscriptionByName", mock.Anything, "ns1", "sub1").Return(sub, nil)
 	err := em.CreateDurableSubscription(em.ctx, sub)
-	assert.Regexp(t, "FF10193", err.Error())
+	assert.Regexp(t, "FF10193", err)
 }
 
 func TestCreateDurableSubscriptionDefaultSubCannotParse(t *testing.T) {
@@ -152,7 +152,7 @@ func TestCreateDurableSubscriptionDefaultSubCannotParse(t *testing.T) {
 	}
 	mdi.On("GetSubscriptionByName", mock.Anything, "ns1", "sub1").Return(nil, nil)
 	err := em.CreateDurableSubscription(em.ctx, sub)
-	assert.Regexp(t, "FF10171", err.Error())
+	assert.Regexp(t, "FF10171", err)
 }
 
 func TestCreateDurableSubscriptionBadFirstEvent(t *testing.T) {
@@ -172,7 +172,7 @@ func TestCreateDurableSubscriptionBadFirstEvent(t *testing.T) {
 	}
 	mdi.On("GetSubscriptionByName", mock.Anything, "ns1", "sub1").Return(nil, nil)
 	err := em.CreateDurableSubscription(em.ctx, sub)
-	assert.Regexp(t, "FF10191", err.Error())
+	assert.Regexp(t, "FF10191", err)
 }
 
 func TestCreateDurableSubscriptionNegativeFirstEvent(t *testing.T) {
@@ -192,7 +192,7 @@ func TestCreateDurableSubscriptionNegativeFirstEvent(t *testing.T) {
 	}
 	mdi.On("GetSubscriptionByName", mock.Anything, "ns1", "sub1").Return(nil, nil)
 	err := em.CreateDurableSubscription(em.ctx, sub)
-	assert.Regexp(t, "FF10192", err.Error())
+	assert.Regexp(t, "FF10192", err)
 }
 
 func TestCreateDurableSubscriptionGetHighestSequenceFailure(t *testing.T) {

--- a/internal/events/event_manager_test.go
+++ b/internal/events/event_manager_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kaleido-io/firefly/internal/config"
 	"github.com/kaleido-io/firefly/mocks/broadcastmocks"
 	"github.com/kaleido-io/firefly/mocks/databasemocks"
+	"github.com/kaleido-io/firefly/mocks/datamocks"
 	"github.com/kaleido-io/firefly/mocks/eventsmocks"
 	"github.com/kaleido-io/firefly/mocks/publicstoragemocks"
 	"github.com/kaleido-io/firefly/pkg/fftypes"
@@ -38,8 +39,9 @@ func newTestEventManager(t *testing.T) (*eventManager, func()) {
 	mpi := &publicstoragemocks.Plugin{}
 	met := &eventsmocks.Plugin{}
 	mbm := &broadcastmocks.Manager{}
+	mdm := &datamocks.Manager{}
 	met.On("Name").Return("ut").Maybe()
-	em, err := NewEventManager(ctx, mpi, mdi, mbm)
+	em, err := NewEventManager(ctx, mpi, mdi, mbm, mdm)
 	assert.NoError(t, err)
 	return em.(*eventManager), cancel
 }
@@ -62,7 +64,7 @@ func TestStartStop(t *testing.T) {
 }
 
 func TestStartStopBadDependencies(t *testing.T) {
-	_, err := NewEventManager(context.Background(), nil, nil, nil)
+	_, err := NewEventManager(context.Background(), nil, nil, nil, nil)
 	assert.Regexp(t, "FF10128", err)
 
 }
@@ -73,7 +75,8 @@ func TestStartStopBadTransports(t *testing.T) {
 	mdi := &databasemocks.Plugin{}
 	mpi := &publicstoragemocks.Plugin{}
 	mbm := &broadcastmocks.Manager{}
-	_, err := NewEventManager(context.Background(), mpi, mdi, mbm)
+	mdm := &datamocks.Manager{}
+	_, err := NewEventManager(context.Background(), mpi, mdi, mbm, mdm)
 	assert.Regexp(t, "FF10172", err)
 
 }

--- a/internal/events/offset_calc.go
+++ b/internal/events/offset_calc.go
@@ -1,3 +1,19 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package events
 
 import (

--- a/internal/events/sequenced_broadcast_batch_test.go
+++ b/internal/events/sequenced_broadcast_batch_test.go
@@ -92,7 +92,7 @@ func TestSequencedBroadcastRetrieveIPFSFail(t *testing.T) {
 
 	err := em.SequencedBroadcastBatch(batch, "0x12345", "tx1", nil)
 	mpi.AssertExpectations(t)
-	assert.Regexp(t, "FF10158", err.Error())
+	assert.Regexp(t, "FF10158", err)
 }
 
 func TestSequencedBroadcastBatchBadData(t *testing.T) {

--- a/internal/events/subscription_manager_test.go
+++ b/internal/events/subscription_manager_test.go
@@ -134,7 +134,7 @@ func TestRegisterEphemeralSubscriptionsFail(t *testing.T) {
 	err = be.EphemeralSubscription("conn1", "ns1", fftypes.SubscriptionFilter{
 		Topic: "[[[[[ !wrong",
 	}, fftypes.SubscriptionOptions{})
-	assert.Regexp(t, "FF10171", err.Error())
+	assert.Regexp(t, "FF10171", err)
 	assert.Empty(t, sm.connections["conn1"].dispatchers)
 
 }
@@ -144,7 +144,7 @@ func TestSubManagerBadPlugin(t *testing.T) {
 	config.Reset()
 	config.Set(config.EventTransportsEnabled, []string{"!unknown!"})
 	_, err := newSubscriptionManager(context.Background(), mdi, newEventNotifier(context.Background()))
-	assert.Regexp(t, "FF10172", err.Error())
+	assert.Regexp(t, "FF10172", err)
 }
 
 func TestSubManagerTransportInitError(t *testing.T) {
@@ -213,7 +213,7 @@ func TestCreateSubscriptionBadTransport(t *testing.T) {
 	sm, cancel := newTestSubManager(t, mdi, mei)
 	defer cancel()
 	_, err := sm.parseSubscriptionDef(sm.ctx, &fftypes.Subscription{})
-	assert.Regexp(t, "FF1017", err.Error())
+	assert.Regexp(t, "FF1017", err)
 }
 
 func TestCreateSubscriptionBadEventilter(t *testing.T) {
@@ -227,7 +227,7 @@ func TestCreateSubscriptionBadEventilter(t *testing.T) {
 		},
 		Transport: "ut",
 	})
-	assert.Regexp(t, "FF10171.*events", err.Error())
+	assert.Regexp(t, "FF10171.*events", err)
 }
 
 func TestCreateSubscriptionBadTopicFilter(t *testing.T) {
@@ -241,7 +241,7 @@ func TestCreateSubscriptionBadTopicFilter(t *testing.T) {
 		},
 		Transport: "ut",
 	})
-	assert.Regexp(t, "FF10171.*topic", err.Error())
+	assert.Regexp(t, "FF10171.*topic", err)
 }
 
 func TestCreateSubscriptionBadContextFilter(t *testing.T) {
@@ -255,7 +255,7 @@ func TestCreateSubscriptionBadContextFilter(t *testing.T) {
 		},
 		Transport: "ut",
 	})
-	assert.Regexp(t, "FF10171.*context", err.Error())
+	assert.Regexp(t, "FF10171.*context", err)
 }
 
 func TestCreateSubscriptionBadGroupFilter(t *testing.T) {
@@ -269,7 +269,7 @@ func TestCreateSubscriptionBadGroupFilter(t *testing.T) {
 		},
 		Transport: "ut",
 	})
-	assert.Regexp(t, "FF10171.*group", err.Error())
+	assert.Regexp(t, "FF10171.*group", err)
 }
 
 func TestDispatchDeliveryResponseOK(t *testing.T) {
@@ -317,7 +317,7 @@ func TestDispatchDeliveryResponseInvalidSubscription(t *testing.T) {
 			ID: fftypes.NewUUID(),
 		},
 	})
-	assert.Regexp(t, "FF10181", err.Error())
+	assert.Regexp(t, "FF10181", err)
 }
 
 func TestConnIDSafetyChecking(t *testing.T) {
@@ -336,13 +336,13 @@ func TestConnIDSafetyChecking(t *testing.T) {
 	}
 
 	err := be2.RegisterConnection("conn1", func(sr fftypes.SubscriptionRef) bool { return true })
-	assert.Regexp(t, "FF10190", err.Error())
+	assert.Regexp(t, "FF10190", err)
 
 	err = be2.EphemeralSubscription("conn1", "ns1", fftypes.SubscriptionFilter{}, fftypes.SubscriptionOptions{})
-	assert.Regexp(t, "FF10190", err.Error())
+	assert.Regexp(t, "FF10190", err)
 
 	err = be2.DeliveryResponse("conn1", fftypes.EventDeliveryResponse{})
-	assert.Regexp(t, "FF10190", err.Error())
+	assert.Regexp(t, "FF10190", err)
 
 	be2.ConnnectionClosed("conn1")
 

--- a/internal/events/websockets/websockets_test.go
+++ b/internal/events/websockets/websockets_test.go
@@ -309,7 +309,7 @@ func TestHandleAckWithAutoAck(t *testing.T) {
 	err := wsc.handleAck(&fftypes.WSClientActionAckPayload{
 		ID: eventUUID,
 	})
-	assert.Regexp(t, "FF10180", err.Error())
+	assert.Regexp(t, "FF10180", err)
 }
 
 func TestHandleStartFlippingAutoAck(t *testing.T) {
@@ -327,7 +327,7 @@ func TestHandleStartFlippingAutoAck(t *testing.T) {
 	err := wsc.handleStart(&fftypes.WSClientActionStartPayload{
 		AutoAck: &no,
 	})
-	assert.Regexp(t, "FF10179", err.Error())
+	assert.Regexp(t, "FF10179", err)
 }
 
 func TestHandleAckMultipleStartedMissingSub(t *testing.T) {
@@ -343,7 +343,7 @@ func TestHandleAckMultipleStartedMissingSub(t *testing.T) {
 	err := wsc.handleAck(&fftypes.WSClientActionAckPayload{
 		ID: eventUUID,
 	})
-	assert.Regexp(t, "FF10175", err.Error())
+	assert.Regexp(t, "FF10175", err)
 
 }
 
@@ -377,7 +377,7 @@ func TestHandleAckNoneInflight(t *testing.T) {
 		inflight:     []*fftypes.EventDeliveryResponse{},
 	}
 	err := wsc.handleAck(&fftypes.WSClientActionAckPayload{})
-	assert.Regexp(t, "FF10175", err.Error())
+	assert.Regexp(t, "FF10175", err)
 }
 
 func TestProtocolErrorSwallowsSendError(t *testing.T) {
@@ -435,7 +435,7 @@ func TestConnectionDispatchAfterClose(t *testing.T) {
 		ctx: ctx,
 	}
 	err := wsc.dispatch(&fftypes.EventDelivery{})
-	assert.Regexp(t, "FF10160", err.Error())
+	assert.Regexp(t, "FF10160", err)
 }
 
 func TestWebsocketDispatchAfterClose(t *testing.T) {
@@ -444,7 +444,7 @@ func TestWebsocketDispatchAfterClose(t *testing.T) {
 		connections: make(map[string]*websocketConnection),
 	}
 	err := ws.DeliveryRequest("gone", &fftypes.EventDelivery{})
-	assert.Regexp(t, "FF10173", err.Error())
+	assert.Regexp(t, "FF10173", err)
 }
 
 func TestDispatchAutoAck(t *testing.T) {

--- a/internal/i18n/en_translations.go
+++ b/internal/i18n/en_translations.go
@@ -121,4 +121,6 @@ var (
 	MsgDataInvalidHash             = ffm("FF10201", "Invalid data: hashes do not match Hash=%s Expected=%s", 400)
 	MsgSystemNSDescription         = ffm("FF10202", "FireFly system namespace")
 	MsgNilID                       = ffm("FF10203", "ID is nil")
+	MsgDataReferenceUnresolvable   = ffm("FF10204", "Data reference %d cannot be resolved", 400)
+	MsgDataMissing                 = ffm("FF10205", "Data entry %d has neither 'id' to refer to existing data, or 'value' to include in-line JSON data", 400)
 )

--- a/internal/i18n/en_translations.go
+++ b/internal/i18n/en_translations.go
@@ -123,4 +123,5 @@ var (
 	MsgNilID                       = ffm("FF10203", "ID is nil")
 	MsgDataReferenceUnresolvable   = ffm("FF10204", "Data reference %d cannot be resolved", 400)
 	MsgDataMissing                 = ffm("FF10205", "Data entry %d has neither 'id' to refer to existing data, or 'value' to include in-line JSON data", 400)
+	MsgAuthorInvalid               = ffm("FF10206", "Invalid header.author in message", 400)
 )

--- a/internal/oapispec/openapi3_test.go
+++ b/internal/oapispec/openapi3_test.go
@@ -51,14 +51,20 @@ func TestOpenAPI3SwaggerGen(t *testing.T) {
 			JSONOutputCode:  http.StatusOK,
 		},
 		{
-			Name:            "op2",
-			Path:            "example2",
-			Method:          http.MethodGet,
-			PathParams:      nil,
-			QueryParams:     nil,
-			FilterFactory:   database.MessageQueryFactory,
-			Description:     i18n.MsgTBD,
-			JSONInputValue:  func() interface{} { return nil },
+			Name:           "op2",
+			Path:           "example2",
+			Method:         http.MethodGet,
+			PathParams:     nil,
+			QueryParams:    nil,
+			FilterFactory:  database.MessageQueryFactory,
+			Description:    i18n.MsgTBD,
+			JSONInputValue: func() interface{} { return nil },
+			JSONInputSchema: `{
+				"type": "object",
+				"properties": {
+					"id": "string"
+				}
+			}`,
 			JSONOutputValue: func() interface{} { return []*fftypes.Batch{} },
 			JSONOutputCode:  http.StatusOK,
 		},
@@ -109,6 +115,25 @@ func TestDuplicateOperationIDCheck(t *testing.T) {
 		{Name: "op1"}, {Name: "op1"},
 	}
 	assert.PanicsWithValue(t, "Duplicate/invalid name (used as operation ID in swagger): op1", func() {
+		_ = SwaggerGen(context.Background(), routes)
+	})
+}
+
+func TestBadCustomSchema(t *testing.T) {
+
+	config.Reset()
+	routes := []*Route{
+		{
+			Name:            "op1",
+			Path:            "namespaces/{ns}/example1/{id}",
+			Method:          http.MethodPost,
+			JSONInputValue:  func() interface{} { return &fftypes.Message{} },
+			JSONInputMask:   []string{"id"},
+			JSONOutputCode:  http.StatusOK,
+			JSONInputSchema: `!json`,
+		},
+	}
+	assert.PanicsWithValue(t, "invalid schema for *fftypes.Message: invalid character '!' looking for beginning of value", func() {
 		_ = SwaggerGen(context.Background(), routes)
 	})
 }

--- a/internal/oapispec/routes.go
+++ b/internal/oapispec/routes.go
@@ -45,6 +45,8 @@ type Route struct {
 	JSONInputValue func() interface{}
 	// JSONInputMask are fields that aren't available for users to supply on input
 	JSONInputMask []string
+	// JSONInputSchema is a custom schema definition, for the case where the auto-gen + mask isn't good enough
+	JSONInputSchema string
 	// JSONOutputValue is a function that returns a pointer to a structure to take JSON output
 	JSONOutputValue func() interface{}
 	// JSONOutputCode is the success response code

--- a/internal/oapispec/routes.go
+++ b/internal/oapispec/routes.go
@@ -74,6 +74,8 @@ type PathParam struct {
 type QueryParam struct {
 	// Name is the name of the parameter, from the Gorilla path mux
 	Name string
+	// IsBool if this is a boolean query
+	IsBool bool
 	// Default is the value that will be used in the case no value is supplied
 	Default string
 	// Example is a field to fill in, in the helper UI

--- a/internal/orchestrator/broadcast_test.go
+++ b/internal/orchestrator/broadcast_test.go
@@ -32,7 +32,7 @@ func TestBroadcastDatatypeBadType(t *testing.T) {
 	_, err := or.BroadcastDatatype(context.Background(), "ns1", &fftypes.Datatype{
 		Validator: fftypes.ValidatorType("wrong"),
 	})
-	assert.Regexp(t, "FF10132.*validator", err.Error())
+	assert.Regexp(t, "FF10132.*validator", err)
 }
 
 func TestBroadcastDatatypeNSGetFail(t *testing.T) {
@@ -49,14 +49,14 @@ func TestBroadcastDatatypeNSGetFail(t *testing.T) {
 func TestBroadcastDatatypeBadValue(t *testing.T) {
 	or := newTestOrchestrator()
 	or.mdi.On("GetNamespace", mock.Anything, mock.Anything).Return(&fftypes.Namespace{Name: "ns1"}, nil)
-	or.mdm.On("CheckDatatype", mock.Anything, mock.Anything).Return(nil)
+	or.mdm.On("CheckDatatype", mock.Anything, "ns1", mock.Anything).Return(nil)
 	_, err := or.BroadcastDatatype(context.Background(), "ns1", &fftypes.Datatype{
 		Namespace: "ns1",
 		Name:      "ent1",
 		Version:   "0.0.1",
 		Value:     fftypes.Byteable(`!unparsable`),
 	})
-	assert.Regexp(t, "FF10137.*value", err.Error())
+	assert.Regexp(t, "FF10137.*value", err)
 }
 
 func TestBroadcastUpsertFail(t *testing.T) {
@@ -64,7 +64,7 @@ func TestBroadcastUpsertFail(t *testing.T) {
 
 	or.mdi.On("UpsertData", mock.Anything, mock.Anything, true, false).Return(fmt.Errorf("pop"))
 	or.mdi.On("GetNamespace", mock.Anything, mock.Anything).Return(&fftypes.Namespace{Name: "ns1"}, nil)
-	or.mdm.On("CheckDatatype", mock.Anything, mock.Anything).Return(nil)
+	or.mdm.On("CheckDatatype", mock.Anything, "ns1", mock.Anything).Return(nil)
 
 	_, err := or.BroadcastDatatype(context.Background(), "ns1", &fftypes.Datatype{
 		Namespace: "ns1",
@@ -81,7 +81,7 @@ func TestBroadcastDatatypeInvalid(t *testing.T) {
 
 	or.mdi.On("UpsertData", mock.Anything, mock.Anything, true, false).Return(nil)
 	or.mdi.On("GetNamespace", mock.Anything, mock.Anything).Return(&fftypes.Namespace{Name: "ns1"}, nil)
-	or.mdm.On("CheckDatatype", mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
+	or.mdm.On("CheckDatatype", mock.Anything, "ns1", mock.Anything).Return(fmt.Errorf("pop"))
 
 	_, err := or.BroadcastDatatype(context.Background(), "ns1", &fftypes.Datatype{
 		Namespace: "ns1",
@@ -98,7 +98,7 @@ func TestBroadcastBroadcastFail(t *testing.T) {
 
 	or.mdi.On("UpsertData", mock.Anything, mock.Anything, true, false).Return(nil)
 	or.mdi.On("GetNamespace", mock.Anything, mock.Anything).Return(&fftypes.Namespace{Name: "ns1"}, nil)
-	or.mdm.On("CheckDatatype", mock.Anything, mock.Anything).Return(nil)
+	or.mdm.On("CheckDatatype", mock.Anything, "ns1", mock.Anything).Return(nil)
 	or.mbm.On("BroadcastMessage", mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
 
 	_, err := or.BroadcastDatatype(context.Background(), "ns1", &fftypes.Datatype{
@@ -116,7 +116,7 @@ func TestBroadcastOk(t *testing.T) {
 
 	or.mdi.On("UpsertData", mock.Anything, mock.Anything, true, false).Return(nil)
 	or.mdi.On("GetNamespace", mock.Anything, mock.Anything).Return(&fftypes.Namespace{Name: "ns1"}, nil)
-	or.mdm.On("CheckDatatype", mock.Anything, mock.Anything).Return(nil)
+	or.mdm.On("CheckDatatype", mock.Anything, "ns1", mock.Anything).Return(nil)
 	or.mbm.On("BroadcastMessage", mock.Anything, mock.Anything).Return(nil)
 
 	_, err := or.BroadcastDatatype(context.Background(), "ns1", &fftypes.Datatype{
@@ -134,7 +134,7 @@ func TestBroadcastNamespaceBadName(t *testing.T) {
 	_, err := or.BroadcastNamespace(context.Background(), &fftypes.Namespace{
 		Name: "!ns",
 	})
-	assert.Regexp(t, "FF10131.*name", err.Error())
+	assert.Regexp(t, "FF10131.*name", err)
 }
 
 func TestBroadcastNamespaceDescriptionTooLong(t *testing.T) {
@@ -149,14 +149,14 @@ func TestBroadcastNamespaceDescriptionTooLong(t *testing.T) {
 		Name:        "ns1",
 		Description: buff.String(),
 	})
-	assert.Regexp(t, "FF10188.*description", err.Error())
+	assert.Regexp(t, "FF10188.*description", err)
 }
 
 func TestBroadcastNamespaceBroadcastOk(t *testing.T) {
 	or := newTestOrchestrator()
 	or.mdi.On("GetNamespace", mock.Anything, mock.Anything).Return(&fftypes.Namespace{Name: "ns1"}, nil)
 	or.mdi.On("UpsertData", mock.Anything, mock.Anything, true, false).Return(nil)
-	or.mdm.On("CheckDatatype", mock.Anything, mock.Anything).Return(nil)
+	or.mdm.On("CheckDatatype", mock.Anything, "ns1", mock.Anything).Return(nil)
 	or.mbm.On("BroadcastMessage", mock.Anything, mock.Anything).Return(nil)
 	buff := strings.Builder{}
 	buff.Grow(4097)

--- a/internal/orchestrator/data_query.go
+++ b/internal/orchestrator/data_query.go
@@ -70,7 +70,11 @@ func (or *orchestrator) GetMessageByID(ctx context.Context, ns, id string) (*fft
 	if err != nil {
 		return nil, err
 	}
-	return or.database.GetMessageByID(ctx, u)
+	msg, err := or.database.GetMessageByID(ctx, u)
+	if err == nil && msg == nil {
+		return nil, i18n.NewError(ctx, i18n.Msg404NotFound)
+	}
+	return msg, err
 }
 
 func (or *orchestrator) GetBatchByID(ctx context.Context, ns, id string) (*fftypes.Batch, error) {
@@ -135,6 +139,15 @@ func (or *orchestrator) GetMessageOperations(ctx context.Context, ns, id string,
 	filter = or.scopeNS(ns, filter)
 	filter = filter.Condition(filter.Builder().Eq("message", id))
 	return or.database.GetOperations(ctx, filter)
+}
+
+func (or *orchestrator) GetMessageData(ctx context.Context, ns, id string) ([]*fftypes.Data, error) {
+	msg, err := or.GetMessageByID(ctx, ns, id)
+	if err != nil || msg == nil {
+		return nil, err
+	}
+	data, _, err := or.data.GetMessageData(ctx, msg, true)
+	return data, err
 }
 
 func (or *orchestrator) GetMessageEvents(ctx context.Context, ns, id string, filter database.AndFilter) ([]*fftypes.Event, error) {

--- a/internal/orchestrator/data_query.go
+++ b/internal/orchestrator/data_query.go
@@ -86,7 +86,7 @@ func (or *orchestrator) GetDataByID(ctx context.Context, ns, id string) (*fftype
 	if err != nil {
 		return nil, err
 	}
-	return or.database.GetDataByID(ctx, u)
+	return or.database.GetDataByID(ctx, u, true)
 }
 
 func (or *orchestrator) GetDatatypeByID(ctx context.Context, ns, id string) (*fftypes.Datatype, error) {

--- a/internal/orchestrator/data_query_test.go
+++ b/internal/orchestrator/data_query_test.go
@@ -45,7 +45,7 @@ func TestGetTransactionByID(t *testing.T) {
 func TestGetTransactionByIDBadID(t *testing.T) {
 	or := newTestOrchestrator()
 	_, err := or.GetTransactionByID(context.Background(), "", "")
-	assert.Regexp(t, "FF10142", err.Error())
+	assert.Regexp(t, "FF10142", err)
 }
 
 func TestGetNamespaces(t *testing.T) {
@@ -78,7 +78,7 @@ func TestGetMessageByID(t *testing.T) {
 func TestGetMessageByIDBadID(t *testing.T) {
 	or := newTestOrchestrator()
 	_, err := or.GetMessageByID(context.Background(), "", "")
-	assert.Regexp(t, "FF10142", err.Error())
+	assert.Regexp(t, "FF10142", err)
 }
 
 func TestGetMessages(t *testing.T) {
@@ -105,7 +105,7 @@ func TestGetMessagesForDataBadID(t *testing.T) {
 	or := newTestOrchestrator()
 	f := database.MessageQueryFactory.NewFilter(context.Background()).And()
 	_, err := or.GetMessagesForData(context.Background(), "!wrong", "!bad", f)
-	assert.Regexp(t, "FF10142", err.Error())
+	assert.Regexp(t, "FF10142", err)
 }
 
 func TestGetMessageOperations(t *testing.T) {
@@ -164,7 +164,7 @@ func TestGetBatchByID(t *testing.T) {
 func TestGetBatchByIDBadID(t *testing.T) {
 	or := newTestOrchestrator()
 	_, err := or.GetBatchByID(context.Background(), "", "")
-	assert.Regexp(t, "FF10142", err.Error())
+	assert.Regexp(t, "FF10142", err)
 }
 
 func TestGetBatches(t *testing.T) {
@@ -180,7 +180,7 @@ func TestGetBatches(t *testing.T) {
 func TestGetDataByID(t *testing.T) {
 	or := newTestOrchestrator()
 	u := fftypes.NewUUID()
-	or.mdi.On("GetDataByID", mock.Anything, u).Return(nil, nil)
+	or.mdi.On("GetDataByID", mock.Anything, u, true).Return(nil, nil)
 	_, err := or.GetDataByID(context.Background(), "ns1", u.String())
 	assert.NoError(t, err)
 }
@@ -188,7 +188,7 @@ func TestGetDataByID(t *testing.T) {
 func TestGetDataByIDBadID(t *testing.T) {
 	or := newTestOrchestrator()
 	_, err := or.GetDataByID(context.Background(), "", "")
-	assert.Regexp(t, "FF10142", err.Error())
+	assert.Regexp(t, "FF10142", err)
 }
 
 func TestGetData(t *testing.T) {
@@ -212,7 +212,7 @@ func TestGetDataDefsByID(t *testing.T) {
 func TestGetDataDefsByIDBadID(t *testing.T) {
 	or := newTestOrchestrator()
 	_, err := or.GetDatatypeByID(context.Background(), "", "")
-	assert.Regexp(t, "FF10142", err.Error())
+	assert.Regexp(t, "FF10142", err)
 }
 
 func TestGetOperationByID(t *testing.T) {
@@ -226,7 +226,7 @@ func TestGetOperationByID(t *testing.T) {
 func TestGetOperationIDBadID(t *testing.T) {
 	or := newTestOrchestrator()
 	_, err := or.GetOperationByID(context.Background(), "", "")
-	assert.Regexp(t, "FF10142", err.Error())
+	assert.Regexp(t, "FF10142", err)
 }
 
 func TestGetEventByID(t *testing.T) {
@@ -240,7 +240,7 @@ func TestGetEventByID(t *testing.T) {
 func TestGetEventIDBadID(t *testing.T) {
 	or := newTestOrchestrator()
 	_, err := or.GetEventByID(context.Background(), "", "")
-	assert.Regexp(t, "FF10142", err.Error())
+	assert.Regexp(t, "FF10142", err)
 }
 
 func TestGetDatatypes(t *testing.T) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -204,7 +204,7 @@ func (or *orchestrator) initComponents(ctx context.Context) (err error) {
 	}
 
 	if or.events == nil {
-		or.events, err = events.NewEventManager(ctx, or.publicstorage, or.database, or.broadcast)
+		or.events, err = events.NewEventManager(ctx, or.publicstorage, or.database, or.broadcast, or.data)
 		if err != nil {
 			return err
 		}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -66,7 +66,7 @@ type Orchestrator interface {
 	GetNamespaces(ctx context.Context, filter database.AndFilter) ([]*fftypes.Namespace, error)
 	GetTransactionByID(ctx context.Context, ns, id string) (*fftypes.Transaction, error)
 	GetTransactions(ctx context.Context, ns string, filter database.AndFilter) ([]*fftypes.Transaction, error)
-	GetMessageByID(ctx context.Context, ns, id string) (*fftypes.Message, error)
+	GetMessageByID(ctx context.Context, ns, id string, withValues bool) (*fftypes.MessageInput, error)
 	GetMessages(ctx context.Context, ns string, filter database.AndFilter) ([]*fftypes.Message, error)
 	GetMessageOperations(ctx context.Context, ns, id string, filter database.AndFilter) ([]*fftypes.Operation, error)
 	GetMessageEvents(ctx context.Context, ns, id string, filter database.AndFilter) ([]*fftypes.Event, error)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -70,6 +70,7 @@ type Orchestrator interface {
 	GetMessages(ctx context.Context, ns string, filter database.AndFilter) ([]*fftypes.Message, error)
 	GetMessageOperations(ctx context.Context, ns, id string, filter database.AndFilter) ([]*fftypes.Operation, error)
 	GetMessageEvents(ctx context.Context, ns, id string, filter database.AndFilter) ([]*fftypes.Event, error)
+	GetMessageData(ctx context.Context, ns, id string) ([]*fftypes.Data, error)
 	GetMessagesForData(ctx context.Context, ns, dataID string, filter database.AndFilter) ([]*fftypes.Message, error)
 	GetBatchByID(ctx context.Context, ns, id string) (*fftypes.Batch, error)
 	GetBatches(ctx context.Context, ns string, filter database.AndFilter) ([]*fftypes.Batch, error)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -53,6 +53,7 @@ type Orchestrator interface {
 	// Broadcasts
 	BroadcastNamespace(ctx context.Context, s *fftypes.Namespace) (*fftypes.Message, error)
 	BroadcastDatatype(ctx context.Context, ns string, s *fftypes.Datatype) (*fftypes.Message, error)
+	BroadcastMessage(ctx context.Context, ns string, in *fftypes.MessageInput) (out *fftypes.Message, err error)
 
 	// Subscription management
 	GetSubscriptions(ctx context.Context, ns string, filter database.AndFilter) ([]*fftypes.Subscription, error)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -85,7 +85,7 @@ func TestBadDatabasePlugin(t *testing.T) {
 	config.Set(config.DatabaseType, "wrong")
 	or.database = nil
 	err := or.Init(context.Background())
-	assert.Regexp(t, "FF10122.*wrong", err.Error())
+	assert.Regexp(t, "FF10122.*wrong", err)
 }
 
 func TestBadDatabaseInitFail(t *testing.T) {
@@ -102,7 +102,7 @@ func TestBadBlockchainPlugin(t *testing.T) {
 	or.blockchain = nil
 	or.mdi.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	err := or.Init(context.Background())
-	assert.Regexp(t, "FF10110.*wrong", err.Error())
+	assert.Regexp(t, "FF10110.*wrong", err)
 }
 
 func TestBlockchaiInitFail(t *testing.T) {
@@ -130,7 +130,7 @@ func TestBadPublicStoragePlugin(t *testing.T) {
 	or.mbi.On("Init", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	or.mbi.On("VerifyIdentitySyntax", mock.Anything, mock.Anything, mock.Anything).Return("", nil)
 	err := or.Init(context.Background())
-	assert.Regexp(t, "FF10134.*wrong", err.Error())
+	assert.Regexp(t, "FF10134.*wrong", err)
 }
 
 func TestBadPublicStorageInitFail(t *testing.T) {
@@ -148,7 +148,7 @@ func TestInitEventsComponentFail(t *testing.T) {
 	or.database = nil
 	or.events = nil
 	err := or.initComponents(context.Background())
-	assert.Regexp(t, "FF10128", err.Error())
+	assert.Regexp(t, "FF10128", err)
 }
 
 func TestInitBatchComponentFail(t *testing.T) {
@@ -156,7 +156,7 @@ func TestInitBatchComponentFail(t *testing.T) {
 	or.database = nil
 	or.batch = nil
 	err := or.initComponents(context.Background())
-	assert.Regexp(t, "FF10128", err.Error())
+	assert.Regexp(t, "FF10128", err)
 }
 
 func TestInitBroadcastComponentFail(t *testing.T) {
@@ -164,7 +164,7 @@ func TestInitBroadcastComponentFail(t *testing.T) {
 	or.database = nil
 	or.broadcast = nil
 	err := or.initComponents(context.Background())
-	assert.Regexp(t, "FF10128", err.Error())
+	assert.Regexp(t, "FF10128", err)
 }
 
 func TestInitDataComponentFail(t *testing.T) {
@@ -172,7 +172,7 @@ func TestInitDataComponentFail(t *testing.T) {
 	or.database = nil
 	or.data = nil
 	err := or.initComponents(context.Background())
-	assert.Regexp(t, "FF10128", err.Error())
+	assert.Regexp(t, "FF10128", err)
 }
 
 func TestStartBatchFail(t *testing.T) {
@@ -181,7 +181,7 @@ func TestStartBatchFail(t *testing.T) {
 	or.mba.On("Start").Return(fmt.Errorf("pop"))
 	or.mbi.On("Start").Return(nil)
 	err := or.Start()
-	assert.Regexp(t, "pop", err.Error())
+	assert.Regexp(t, "pop", err)
 }
 
 func TestStartStopOk(t *testing.T) {
@@ -208,7 +208,7 @@ func TestInitNamespacesBadName(t *testing.T) {
 	})
 	or := newTestOrchestrator()
 	err := or.initNamespaces(context.Background())
-	assert.Regexp(t, "FF10131", err.Error())
+	assert.Regexp(t, "FF10131", err)
 }
 
 func TestInitNamespacesGetFail(t *testing.T) {
@@ -216,7 +216,7 @@ func TestInitNamespacesGetFail(t *testing.T) {
 	or := newTestOrchestrator()
 	or.mdi.On("GetNamespace", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("pop"))
 	err := or.initNamespaces(context.Background())
-	assert.Regexp(t, "pop", err.Error())
+	assert.Regexp(t, "pop", err)
 }
 
 func TestInitNamespacesUpsertFail(t *testing.T) {
@@ -225,7 +225,7 @@ func TestInitNamespacesUpsertFail(t *testing.T) {
 	or.mdi.On("GetNamespace", mock.Anything, mock.Anything).Return(nil, nil)
 	or.mdi.On("UpsertNamespace", mock.Anything, mock.Anything, true).Return(fmt.Errorf("pop"))
 	err := or.initNamespaces(context.Background())
-	assert.Regexp(t, "pop", err.Error())
+	assert.Regexp(t, "pop", err)
 }
 
 func TestInitNamespacesUpsertNotNeeded(t *testing.T) {
@@ -243,7 +243,7 @@ func TestInitNamespacesDefaultMissing(t *testing.T) {
 	or := newTestOrchestrator()
 	config.Set(config.NamespacesPredefined, fftypes.JSONObjectArray{})
 	err := or.initNamespaces(context.Background())
-	assert.Regexp(t, "FF10166", err.Error())
+	assert.Regexp(t, "FF10166", err)
 }
 
 func TestInitNamespacesDupName(t *testing.T) {

--- a/internal/orchestrator/subscriptions_test.go
+++ b/internal/orchestrator/subscriptions_test.go
@@ -38,7 +38,7 @@ func TestCreateSubscriptionBadNamespace(t *testing.T) {
 			Name: "sub1",
 		},
 	})
-	assert.Regexp(t, "FF10131", err.Error())
+	assert.Regexp(t, "FF10131", err)
 }
 
 func TestCreateSubscriptionNamespace(t *testing.T) {
@@ -49,7 +49,7 @@ func TestCreateSubscriptionNamespace(t *testing.T) {
 			Name: "sub1",
 		},
 	})
-	assert.Regexp(t, "FF10187", err.Error())
+	assert.Regexp(t, "FF10187", err)
 }
 
 func TestCreateSubscriptionBadName(t *testing.T) {
@@ -60,7 +60,7 @@ func TestCreateSubscriptionBadName(t *testing.T) {
 			Name: "!sub1",
 		},
 	})
-	assert.Regexp(t, "FF10131", err.Error())
+	assert.Regexp(t, "FF10131", err)
 }
 
 func TestCreateSubscriptionOk(t *testing.T) {
@@ -82,7 +82,7 @@ func TestDeleteSubscriptionBadUUID(t *testing.T) {
 	or := newTestOrchestrator()
 	or.mdi.On("GetSubscriptionByID", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("pop"))
 	err := or.DeleteSubscription(or.ctx, "ns2", "! a UUID")
-	assert.Regexp(t, "FF10142", err.Error())
+	assert.Regexp(t, "FF10142", err)
 }
 
 func TestDeleteSubscriptionLookupError(t *testing.T) {
@@ -103,7 +103,7 @@ func TestDeleteSubscriptionNSMismatch(t *testing.T) {
 	}
 	or.mdi.On("GetSubscriptionByID", mock.Anything, sub.ID).Return(sub, nil)
 	err := or.DeleteSubscription(or.ctx, "ns2", sub.ID.String())
-	assert.Regexp(t, "FF10109", err.Error())
+	assert.Regexp(t, "FF10109", err)
 }
 
 func TestDeleteSubscription(t *testing.T) {
@@ -142,5 +142,5 @@ func TestGetSGetSubscriptionsByID(t *testing.T) {
 func TestGetSubscriptionDefsByIDBadID(t *testing.T) {
 	or := newTestOrchestrator()
 	_, err := or.GetSubscriptionByID(context.Background(), "", "")
-	assert.Regexp(t, "FF10142", err.Error())
+	assert.Regexp(t, "FF10142", err)
 }

--- a/internal/publicstorage/ipfs/ipfs_test.go
+++ b/internal/publicstorage/ipfs/ipfs_test.go
@@ -47,7 +47,7 @@ func TestInitMissingAPIURL(t *testing.T) {
 
 	utConfPrefix.SubPrefix(IPFSConfGatewaySubconf).Set(restclient.HTTPConfigURL, "http://localhost:12345")
 	err := i.Init(context.Background(), utConfPrefix, &publicstoragemocks.Callbacks{})
-	assert.Regexp(t, "FF10138", err.Error())
+	assert.Regexp(t, "FF10138", err)
 }
 
 func TestInitMissingGWURL(t *testing.T) {
@@ -56,7 +56,7 @@ func TestInitMissingGWURL(t *testing.T) {
 
 	utConfPrefix.SubPrefix(IPFSConfAPISubconf).Set(restclient.HTTPConfigURL, "http://localhost:12345")
 	err := i.Init(context.Background(), utConfPrefix, &publicstoragemocks.Callbacks{})
-	assert.Regexp(t, "FF10138", err.Error())
+	assert.Regexp(t, "FF10138", err)
 }
 
 func TestInit(t *testing.T) {
@@ -92,14 +92,14 @@ func TestIPFSHashToBytes32BadData(t *testing.T) {
 	i := IPFS{ctx: context.Background()}
 	ipfsHash := "!!"
 	_, err := i.ipfsHashToBytes32(ipfsHash)
-	assert.Regexp(t, "FF10135", err.Error())
+	assert.Regexp(t, "FF10135", err)
 }
 
 func TestIPFSHashToBytes32WrongLen(t *testing.T) {
 	i := IPFS{ctx: context.Background()}
 	ipfsHash := "QmRAQfHNnknnz8S936M2yJGhhVNA6wXJ4jTRP3VXtptm"
 	_, err := i.ipfsHashToBytes32(ipfsHash)
-	assert.Regexp(t, "FF10135", err.Error())
+	assert.Regexp(t, "FF10135", err)
 }
 
 func TestIPFSUploadSuccess(t *testing.T) {
@@ -150,7 +150,7 @@ func TestIPFSUploadFail(t *testing.T) {
 
 	data := []byte(`hello world`)
 	_, _, err = i.PublishData(context.Background(), bytes.NewReader(data))
-	assert.Regexp(t, "FF10136", err.Error())
+	assert.Regexp(t, "FF10136", err)
 
 }
 
@@ -206,7 +206,7 @@ func TestIPFSDownloadFail(t *testing.T) {
 		httpmock.NewJsonResponderOrPanic(500, map[string]interface{}{"error": "pop"}))
 
 	_, err = i.RetrieveData(context.Background(), &b32)
-	assert.Regexp(t, "FF10136", err.Error())
+	assert.Regexp(t, "FF10136", err)
 
 }
 
@@ -231,6 +231,6 @@ func TestIPFSDownloadError(t *testing.T) {
 		httpmock.NewErrorResponder(fmt.Errorf("pop")))
 
 	_, err = i.RetrieveData(context.Background(), &b32)
-	assert.Regexp(t, "FF10136", err.Error())
+	assert.Regexp(t, "FF10136", err)
 
 }

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -45,7 +45,7 @@ func TestRetryDeadlineTimeout(t *testing.T) {
 	err := r.DoCustomLog(ctx, func(i int) (retry bool, err error) {
 		return true, fmt.Errorf("pop")
 	})
-	assert.Regexp(t, "FF10158", err.Error())
+	assert.Regexp(t, "FF10158", err)
 }
 
 func TestRetryContextCancellled(t *testing.T) {
@@ -58,5 +58,5 @@ func TestRetryContextCancellled(t *testing.T) {
 	err := r.Do(ctx, "unit test", func(i int) (retry bool, err error) {
 		return true, fmt.Errorf("pop")
 	})
-	assert.Regexp(t, "FF10158", err.Error())
+	assert.Regexp(t, "FF10158", err)
 }

--- a/internal/wsclient/wsclient_test.go
+++ b/internal/wsclient/wsclient_test.go
@@ -86,7 +86,7 @@ func TestWSClientBadURL(t *testing.T) {
 	utConfPrefix.Set(restclient.HTTPConfigURL, ":::")
 
 	_, err := New(context.Background(), utConfPrefix, nil)
-	assert.Regexp(t, "FF10162", err.Error())
+	assert.Regexp(t, "FF10162", err)
 }
 
 func TestHTTPToWSURLRemap(t *testing.T) {
@@ -131,7 +131,7 @@ func TestWSFailStartupHttp500(t *testing.T) {
 
 	w, _ := New(context.Background(), utConfPrefix, nil)
 	err := w.Connect()
-	assert.Regexp(t, "FF10161", err.Error())
+	assert.Regexp(t, "FF10161", err)
 }
 
 func TestWSFailStartupConnect(t *testing.T) {
@@ -150,7 +150,7 @@ func TestWSFailStartupConnect(t *testing.T) {
 
 	w, _ := New(context.Background(), utConfPrefix, nil)
 	err := w.Connect()
-	assert.Regexp(t, "FF10161", err.Error())
+	assert.Regexp(t, "FF10161", err)
 }
 
 func TestWSSendClosed(t *testing.T) {
@@ -163,7 +163,7 @@ func TestWSSendClosed(t *testing.T) {
 	w.Close()
 
 	err = w.Send(context.Background(), []byte(`sent after close`))
-	assert.Regexp(t, "FF10160", err.Error())
+	assert.Regexp(t, "FF10160", err)
 }
 
 func TestWSSendCancelledContext(t *testing.T) {
@@ -176,7 +176,7 @@ func TestWSSendCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	err := w.Send(ctx, []byte(`sent after close`))
-	assert.Regexp(t, "FF10159", err.Error())
+	assert.Regexp(t, "FF10159", err)
 }
 
 func TestWSConnectClosed(t *testing.T) {
@@ -187,7 +187,7 @@ func TestWSConnectClosed(t *testing.T) {
 	}
 
 	err := w.connect(false)
-	assert.Regexp(t, "FF10160", err.Error())
+	assert.Regexp(t, "FF10160", err)
 }
 
 func TestWSReadLoopSendFailure(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ import (
 
 func main() {
 	if err := cmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
 	os.Exit(0)

--- a/mocks/broadcastmocks/manager.go
+++ b/mocks/broadcastmocks/manager.go
@@ -29,17 +29,24 @@ func (_m *Manager) BroadcastMessage(ctx context.Context, msg *fftypes.Message) e
 }
 
 // HandleSystemBroadcast provides a mock function with given fields: ctx, msg, data
-func (_m *Manager) HandleSystemBroadcast(ctx context.Context, msg *fftypes.Message, data []*fftypes.Data) error {
+func (_m *Manager) HandleSystemBroadcast(ctx context.Context, msg *fftypes.Message, data []*fftypes.Data) (bool, error) {
 	ret := _m.Called(ctx, msg, data)
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Message, []*fftypes.Data) error); ok {
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Message, []*fftypes.Data) bool); ok {
 		r0 = rf(ctx, msg, data)
 	} else {
-		r0 = ret.Error(0)
+		r0 = ret.Get(0).(bool)
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *fftypes.Message, []*fftypes.Data) error); ok {
+		r1 = rf(ctx, msg, data)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // Start provides a mock function with given fields:

--- a/mocks/broadcastmocks/manager.go
+++ b/mocks/broadcastmocks/manager.go
@@ -28,13 +28,13 @@ func (_m *Manager) BroadcastMessage(ctx context.Context, msg *fftypes.Message) e
 	return r0
 }
 
-// HandleSystemBroadcast provides a mock function with given fields: ctx, msg
-func (_m *Manager) HandleSystemBroadcast(ctx context.Context, msg *fftypes.Message) error {
-	ret := _m.Called(ctx, msg)
+// HandleSystemBroadcast provides a mock function with given fields: ctx, msg, data
+func (_m *Manager) HandleSystemBroadcast(ctx context.Context, msg *fftypes.Message, data []*fftypes.Data) error {
+	ret := _m.Called(ctx, msg, data)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Message) error); ok {
-		r0 = rf(ctx, msg)
+	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Message, []*fftypes.Data) error); ok {
+		r0 = rf(ctx, msg, data)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/mocks/databasemocks/plugin.go
+++ b/mocks/databasemocks/plugin.go
@@ -35,27 +35,6 @@ func (_m *Plugin) Capabilities() *database.Capabilities {
 	return r0
 }
 
-// CheckDataAvailable provides a mock function with given fields: ctx, msg
-func (_m *Plugin) CheckDataAvailable(ctx context.Context, msg *fftypes.Message) (bool, error) {
-	ret := _m.Called(ctx, msg)
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Message) bool); ok {
-		r0 = rf(ctx, msg)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *fftypes.Message) error); ok {
-		r1 = rf(ctx, msg)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // DeleteBlocked provides a mock function with given fields: ctx, id
 func (_m *Plugin) DeleteBlocked(ctx context.Context, id *fftypes.UUID) error {
 	ret := _m.Called(ctx, id)

--- a/mocks/databasemocks/plugin.go
+++ b/mocks/databasemocks/plugin.go
@@ -213,13 +213,13 @@ func (_m *Plugin) GetData(ctx context.Context, filter database.Filter) ([]*fftyp
 	return r0, r1
 }
 
-// GetDataByID provides a mock function with given fields: ctx, id
-func (_m *Plugin) GetDataByID(ctx context.Context, id *fftypes.UUID) (*fftypes.Data, error) {
-	ret := _m.Called(ctx, id)
+// GetDataByID provides a mock function with given fields: ctx, id, withValue
+func (_m *Plugin) GetDataByID(ctx context.Context, id *fftypes.UUID, withValue bool) (*fftypes.Data, error) {
+	ret := _m.Called(ctx, id, withValue)
 
 	var r0 *fftypes.Data
-	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.UUID) *fftypes.Data); ok {
-		r0 = rf(ctx, id)
+	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.UUID, bool) *fftypes.Data); ok {
+		r0 = rf(ctx, id, withValue)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*fftypes.Data)
@@ -227,8 +227,8 @@ func (_m *Plugin) GetDataByID(ctx context.Context, id *fftypes.UUID) (*fftypes.D
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *fftypes.UUID) error); ok {
-		r1 = rf(ctx, id)
+	if rf, ok := ret.Get(1).(func(context.Context, *fftypes.UUID, bool) error); ok {
+		r1 = rf(ctx, id, withValue)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/mocks/datamocks/manager.go
+++ b/mocks/datamocks/manager.go
@@ -16,13 +16,13 @@ type Manager struct {
 	mock.Mock
 }
 
-// CheckDatatype provides a mock function with given fields: ctx, datatype
-func (_m *Manager) CheckDatatype(ctx context.Context, datatype *fftypes.Datatype) error {
-	ret := _m.Called(ctx, datatype)
+// CheckDatatype provides a mock function with given fields: ctx, ns, datatype
+func (_m *Manager) CheckDatatype(ctx context.Context, ns string, datatype *fftypes.Datatype) error {
+	ret := _m.Called(ctx, ns, datatype)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Datatype) error); ok {
-		r0 = rf(ctx, datatype)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *fftypes.Datatype) error); ok {
+		r0 = rf(ctx, ns, datatype)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -30,13 +30,13 @@ func (_m *Manager) CheckDatatype(ctx context.Context, datatype *fftypes.Datatype
 	return r0
 }
 
-// GetMessageData provides a mock function with given fields: ctx, msg
-func (_m *Manager) GetMessageData(ctx context.Context, msg *fftypes.Message) ([]*fftypes.Data, bool, error) {
-	ret := _m.Called(ctx, msg)
+// GetMessageData provides a mock function with given fields: ctx, msg, withValue
+func (_m *Manager) GetMessageData(ctx context.Context, msg *fftypes.Message, withValue bool) ([]*fftypes.Data, bool, error) {
+	ret := _m.Called(ctx, msg, withValue)
 
 	var r0 []*fftypes.Data
-	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Message) []*fftypes.Data); ok {
-		r0 = rf(ctx, msg)
+	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Message, bool) []*fftypes.Data); ok {
+		r0 = rf(ctx, msg, withValue)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*fftypes.Data)
@@ -44,15 +44,15 @@ func (_m *Manager) GetMessageData(ctx context.Context, msg *fftypes.Message) ([]
 	}
 
 	var r1 bool
-	if rf, ok := ret.Get(1).(func(context.Context, *fftypes.Message) bool); ok {
-		r1 = rf(ctx, msg)
+	if rf, ok := ret.Get(1).(func(context.Context, *fftypes.Message, bool) bool); ok {
+		r1 = rf(ctx, msg, withValue)
 	} else {
 		r1 = ret.Get(1).(bool)
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(context.Context, *fftypes.Message) error); ok {
-		r2 = rf(ctx, msg)
+	if rf, ok := ret.Get(2).(func(context.Context, *fftypes.Message, bool) error); ok {
+		r2 = rf(ctx, msg, withValue)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -76,6 +76,29 @@ func (_m *Manager) GetValidator(ctx context.Context, _a1 *fftypes.Data) (data.Va
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, *fftypes.Data) error); ok {
 		r1 = rf(ctx, _a1)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ResolveInputData provides a mock function with given fields: ctx, ns, inData
+func (_m *Manager) ResolveInputData(ctx context.Context, ns string, inData fftypes.InputData) (fftypes.DataRefs, error) {
+	ret := _m.Called(ctx, ns, inData)
+
+	var r0 fftypes.DataRefs
+	if rf, ok := ret.Get(0).(func(context.Context, string, fftypes.InputData) fftypes.DataRefs); ok {
+		r0 = rf(ctx, ns, inData)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(fftypes.DataRefs)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, fftypes.InputData) error); ok {
+		r1 = rf(ctx, ns, inData)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/mocks/datamocks/manager.go
+++ b/mocks/datamocks/manager.go
@@ -5,7 +5,6 @@ package datamocks
 import (
 	context "context"
 
-	data "github.com/kaleido-io/firefly/internal/data"
 	fftypes "github.com/kaleido-io/firefly/pkg/fftypes"
 
 	mock "github.com/stretchr/testify/mock"
@@ -60,29 +59,6 @@ func (_m *Manager) GetMessageData(ctx context.Context, msg *fftypes.Message, wit
 	return r0, r1, r2
 }
 
-// GetValidator provides a mock function with given fields: ctx, _a1
-func (_m *Manager) GetValidator(ctx context.Context, _a1 *fftypes.Data) (data.Validator, error) {
-	ret := _m.Called(ctx, _a1)
-
-	var r0 data.Validator
-	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Data) data.Validator); ok {
-		r0 = rf(ctx, _a1)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(data.Validator)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *fftypes.Data) error); ok {
-		r1 = rf(ctx, _a1)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // ResolveInputData provides a mock function with given fields: ctx, ns, inData
 func (_m *Manager) ResolveInputData(ctx context.Context, ns string, inData fftypes.InputData) (fftypes.DataRefs, error) {
 	ret := _m.Called(ctx, ns, inData)
@@ -99,6 +75,27 @@ func (_m *Manager) ResolveInputData(ctx context.Context, ns string, inData fftyp
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, string, fftypes.InputData) error); ok {
 		r1 = rf(ctx, ns, inData)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ValidateAll provides a mock function with given fields: ctx, _a1
+func (_m *Manager) ValidateAll(ctx context.Context, _a1 []*fftypes.Data) (bool, error) {
+	ret := _m.Called(ctx, _a1)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(context.Context, []*fftypes.Data) bool); ok {
+		r0 = rf(ctx, _a1)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, []*fftypes.Data) error); ok {
+		r1 = rf(ctx, _a1)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/mocks/orchestratormocks/orchestrator.go
+++ b/mocks/orchestratormocks/orchestrator.go
@@ -332,6 +332,29 @@ func (_m *Orchestrator) GetMessageByID(ctx context.Context, ns string, id string
 	return r0, r1
 }
 
+// GetMessageData provides a mock function with given fields: ctx, ns, id
+func (_m *Orchestrator) GetMessageData(ctx context.Context, ns string, id string) ([]*fftypes.Data, error) {
+	ret := _m.Called(ctx, ns, id)
+
+	var r0 []*fftypes.Data
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) []*fftypes.Data); ok {
+		r0 = rf(ctx, ns, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*fftypes.Data)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, ns, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetMessageEvents provides a mock function with given fields: ctx, ns, id, filter
 func (_m *Orchestrator) GetMessageEvents(ctx context.Context, ns string, id string, filter database.AndFilter) ([]*fftypes.Event, error) {
 	ret := _m.Called(ctx, ns, id, filter)

--- a/mocks/orchestratormocks/orchestrator.go
+++ b/mocks/orchestratormocks/orchestrator.go
@@ -309,22 +309,22 @@ func (_m *Orchestrator) GetEvents(ctx context.Context, ns string, filter databas
 	return r0, r1
 }
 
-// GetMessageByID provides a mock function with given fields: ctx, ns, id
-func (_m *Orchestrator) GetMessageByID(ctx context.Context, ns string, id string) (*fftypes.Message, error) {
-	ret := _m.Called(ctx, ns, id)
+// GetMessageByID provides a mock function with given fields: ctx, ns, id, withValues
+func (_m *Orchestrator) GetMessageByID(ctx context.Context, ns string, id string, withValues bool) (*fftypes.MessageInput, error) {
+	ret := _m.Called(ctx, ns, id, withValues)
 
-	var r0 *fftypes.Message
-	if rf, ok := ret.Get(0).(func(context.Context, string, string) *fftypes.Message); ok {
-		r0 = rf(ctx, ns, id)
+	var r0 *fftypes.MessageInput
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, bool) *fftypes.MessageInput); ok {
+		r0 = rf(ctx, ns, id, withValues)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*fftypes.Message)
+			r0 = ret.Get(0).(*fftypes.MessageInput)
 		}
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
-		r1 = rf(ctx, ns, id)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, bool) error); ok {
+		r1 = rf(ctx, ns, id, withValues)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/mocks/orchestratormocks/orchestrator.go
+++ b/mocks/orchestratormocks/orchestrator.go
@@ -42,6 +42,29 @@ func (_m *Orchestrator) BroadcastDatatype(ctx context.Context, ns string, s *fft
 	return r0, r1
 }
 
+// BroadcastMessage provides a mock function with given fields: ctx, ns, in
+func (_m *Orchestrator) BroadcastMessage(ctx context.Context, ns string, in *fftypes.MessageInput) (*fftypes.Message, error) {
+	ret := _m.Called(ctx, ns, in)
+
+	var r0 *fftypes.Message
+	if rf, ok := ret.Get(0).(func(context.Context, string, *fftypes.MessageInput) *fftypes.Message); ok {
+		r0 = rf(ctx, ns, in)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*fftypes.Message)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, *fftypes.MessageInput) error); ok {
+		r1 = rf(ctx, ns, in)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // BroadcastNamespace provides a mock function with given fields: ctx, s
 func (_m *Orchestrator) BroadcastNamespace(ctx context.Context, s *fftypes.Namespace) (*fftypes.Message, error) {
 	ret := _m.Called(ctx, s)

--- a/pkg/database/filter_test.go
+++ b/pkg/database/filter_test.go
@@ -80,7 +80,7 @@ func TestBuildMessageBadInFilterField(t *testing.T) {
 	_, err := fb.And(
 		fb.In("!wrong", []driver.Value{"a", "b", "c"}),
 	).Finalize()
-	assert.Regexp(t, "FF10148", err.Error())
+	assert.Regexp(t, "FF10148", err)
 }
 
 func TestBuildMessageBadInFilterValue(t *testing.T) {
@@ -88,7 +88,7 @@ func TestBuildMessageBadInFilterValue(t *testing.T) {
 	_, err := fb.And(
 		fb.In("sequence", []driver.Value{"!integer"}),
 	).Finalize()
-	assert.Regexp(t, "FF10149", err.Error())
+	assert.Regexp(t, "FF10149", err)
 }
 
 func TestBuildMessageUUIDConvert(t *testing.T) {
@@ -163,19 +163,19 @@ func TestBuildMessageStringConvert(t *testing.T) {
 func TestBuildMessageFailStringConvert(t *testing.T) {
 	fb := MessageQueryFactory.NewFilter(context.Background())
 	_, err := fb.Lt("namespace", map[bool]bool{true: false}).Finalize()
-	assert.Regexp(t, "FF10149.*namespace", err.Error())
+	assert.Regexp(t, "FF10149.*namespace", err)
 }
 
 func TestBuildMessageFailInt64Convert(t *testing.T) {
 	fb := MessageQueryFactory.NewFilter(context.Background())
 	_, err := fb.Lt("sequence", map[bool]bool{true: false}).Finalize()
-	assert.Regexp(t, "FF10149.*sequence", err.Error())
+	assert.Regexp(t, "FF10149.*sequence", err)
 }
 
 func TestBuildMessageFailTimeConvert(t *testing.T) {
 	fb := MessageQueryFactory.NewFilter(context.Background())
 	_, err := fb.Lt("created", map[bool]bool{true: false}).Finalize()
-	assert.Regexp(t, "FF10149.*created", err.Error())
+	assert.Regexp(t, "FF10149.*created", err)
 }
 
 func TestQueryFactoryBadField(t *testing.T) {

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -115,9 +115,6 @@ type PeristenceInterface interface {
 	// GetMessagesForData - List messages where there is a data reference to the specified ID
 	GetMessagesForData(ctx context.Context, dataID *fftypes.UUID, filter Filter) (message []*fftypes.Message, err error)
 
-	// CheckDataAvailable - Check to see if all the data for this message is available
-	CheckDataAvailable(ctx context.Context, msg *fftypes.Message) (bool, error)
-
 	// UpsertData - Upsert a data record
 	// allowHashUpdate=false throws HashMismatch error if the updated message has a different hash
 	UpsertData(ctx context.Context, data *fftypes.Data, allowExisting, allowHashUpdate bool) (err error)

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -126,7 +126,7 @@ type PeristenceInterface interface {
 	UpdateData(ctx context.Context, id *fftypes.UUID, update Update) (err error)
 
 	// GetDataByID - Get a data record by ID
-	GetDataByID(ctx context.Context, id *fftypes.UUID) (message *fftypes.Data, err error)
+	GetDataByID(ctx context.Context, id *fftypes.UUID, withValue bool) (message *fftypes.Data, err error)
 
 	// GetData - Get data
 	GetData(ctx context.Context, filter Filter) (message []*fftypes.Data, err error)

--- a/pkg/database/update.go
+++ b/pkg/database/update.go
@@ -1,7 +1,9 @@
 // Copyright © 2021 Kaleido, Inc.
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this uile except in compliance with the License.
+// you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
@@ -9,7 +11,7 @@
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the speciuic language governing permissions and
+// See the License for the specific language governing permissions and
 // limitations under the License.
 
 package database

--- a/pkg/database/update_test.go
+++ b/pkg/database/update_test.go
@@ -39,13 +39,13 @@ func TestUpdateBuilderOK(t *testing.T) {
 func TestUpdateBuilderBadField(t *testing.T) {
 	u := MessageQueryFactory.NewUpdate(context.Background()).Set("wrong", 12345)
 	_, err := u.Finalize()
-	assert.Regexp(t, "FF10148.*wrong", err.Error())
+	assert.Regexp(t, "FF10148.*wrong", err)
 }
 
 func TestUpdateBuilderBadValue(t *testing.T) {
 	u := MessageQueryFactory.NewUpdate(context.Background()).Set("id", map[bool]bool{true: false})
 	_, err := u.Finalize()
-	assert.Regexp(t, "FF10149.*id", err.Error())
+	assert.Regexp(t, "FF10149.*id", err)
 }
 
 func TestUpdateBuilderGetFields(t *testing.T) {

--- a/pkg/fftypes/data_test.go
+++ b/pkg/fftypes/data_test.go
@@ -38,7 +38,7 @@ func TestDatatypeReference(t *testing.T) {
 func TestSealNoData(t *testing.T) {
 	d := &Data{}
 	err := d.Seal(context.Background())
-	assert.Regexp(t, "FF10199", err.Error())
+	assert.Regexp(t, "FF10199", err)
 }
 
 func TestSealOK(t *testing.T) {

--- a/pkg/fftypes/event.go
+++ b/pkg/fftypes/event.go
@@ -23,6 +23,8 @@ const (
 	// EventTypeMessageConfirmed is the most important event type in the system. This means a message and all of its data
 	// is available for processing by an application. Most applications only need to listen to this event type
 	EventTypeMessageConfirmed EventType = "MessageConfirmed"
+	// EventTypeMessageInvalid occurs if a message is received and confirmed from a sequencing perspective, but is invalid
+	EventTypeMessageInvalid EventType = "MessageInvalid"
 	// EventTypeDataArrivedBroadcast indicates that some data has arrived, over a broadcast transport
 	EventTypeDataArrivedBroadcast EventType = "DataArrivedBroadcast"
 	// EventTypeMessageSequencedBroadcast indicates that a deterministically sequenced message has arrived pinned to a blockchain

--- a/pkg/fftypes/jsondata_test.go
+++ b/pkg/fftypes/jsondata_test.go
@@ -64,7 +64,7 @@ func TestJSONObject(t *testing.T) {
 
 	var badJson JSONObject = map[string]interface{}{"not": map[bool]string{true: "json"}}
 	hash, err = badJson.Hash("badStuff")
-	assert.Regexp(t, "FF10151.*badStuff", err.Error())
+	assert.Regexp(t, "FF10151.*badStuff", err)
 	assert.Nil(t, hash)
 }
 
@@ -108,7 +108,7 @@ func TestJSONObjectArray(t *testing.T) {
 
 	var badJson JSONObjectArray = []JSONObject{{"not": map[bool]string{true: "json"}}}
 	hash, err = badJson.Hash("badStuff")
-	assert.Regexp(t, "FF10151.*badStuff", err.Error())
+	assert.Regexp(t, "FF10151.*badStuff", err)
 	assert.Nil(t, hash)
 
 }

--- a/pkg/fftypes/message.go
+++ b/pkg/fftypes/message.go
@@ -79,9 +79,9 @@ type InputData []*DataRefOrValue
 type DataRefOrValue struct {
 	DataRef
 
-	Validator ValidatorType `json:"validator"`
+	Validator ValidatorType `json:"validator,omitempty"`
 	Datatype  *DatatypeRef  `json:"datatype,omitempty"`
-	Value     Byteable      `json:"value"`
+	Value     Byteable      `json:"value,omitempty"`
 }
 
 // MessageRef is a lightweight data structure that can be used to refer to a message

--- a/pkg/fftypes/message.go
+++ b/pkg/fftypes/message.go
@@ -64,6 +64,27 @@ type Message struct {
 	Data      DataRefs      `json:"data"`
 }
 
+// MessageInput allows API users to submit values in-line in the payload submitted, which
+// will be broken out and stored separately during the call.
+type MessageInput struct {
+	Message
+
+	InputData InputData `json:"data"`
+}
+
+// InputData is an array of data references or values
+type InputData []*DataRefOrValue
+
+// DataRefOrValue allows a value to be specified in-line in the data array of an input
+// message, avoiding the need for a multiple API calls.
+type DataRefOrValue struct {
+	DataRef
+
+	Validator ValidatorType `json:"validator"`
+	Datatype  *DatatypeRef  `json:"datatype,omitempty"`
+	Value     Byteable      `json:"value"`
+}
+
 // MessageRef is a lightweight data structure that can be used to refer to a message
 type MessageRef struct {
 	ID       *UUID    `json:"id,omitempty"`

--- a/pkg/fftypes/message.go
+++ b/pkg/fftypes/message.go
@@ -68,7 +68,6 @@ type Message struct {
 // will be broken out and stored separately during the call.
 type MessageInput struct {
 	Message
-
 	InputData InputData `json:"data"`
 }
 

--- a/pkg/fftypes/message_test.go
+++ b/pkg/fftypes/message_test.go
@@ -41,7 +41,7 @@ func TestSealNilDataID(t *testing.T) {
 		},
 	}
 	err := msg.Seal(context.Background())
-	assert.Regexp(t, "FF10144.*0", err.Error())
+	assert.Regexp(t, "FF10144.*0", err)
 }
 
 func TestVerifyNilDataHash(t *testing.T) {
@@ -51,7 +51,7 @@ func TestVerifyNilDataHash(t *testing.T) {
 		},
 	}
 	err := msg.Verify(context.Background())
-	assert.Regexp(t, "FF10144.*0", err.Error())
+	assert.Regexp(t, "FF10144.*0", err)
 }
 
 func TestSeaDupDataID(t *testing.T) {
@@ -65,7 +65,7 @@ func TestSeaDupDataID(t *testing.T) {
 		},
 	}
 	err := msg.Seal(context.Background())
-	assert.Regexp(t, "FF10145.*1", err.Error())
+	assert.Regexp(t, "FF10145.*1", err)
 }
 
 func TestVerifylDupDataHash(t *testing.T) {
@@ -79,13 +79,13 @@ func TestVerifylDupDataHash(t *testing.T) {
 		},
 	}
 	err := msg.Verify(context.Background())
-	assert.Regexp(t, "FF10145.*1", err.Error())
+	assert.Regexp(t, "FF10145.*1", err)
 }
 
 func TestVerifyNilHashes(t *testing.T) {
 	msg := Message{}
 	err := msg.Verify(context.Background())
-	assert.Regexp(t, "FF10147", err.Error())
+	assert.Regexp(t, "FF10147", err)
 }
 
 func TestVerifyNilMisMatchedHashes(t *testing.T) {
@@ -96,7 +96,7 @@ func TestVerifyNilMisMatchedHashes(t *testing.T) {
 		Hash: NewRandB32(),
 	}
 	err := msg.Verify(context.Background())
-	assert.Regexp(t, "FF10146", err.Error())
+	assert.Regexp(t, "FF10146", err)
 }
 
 func TestSealKnownMessage(t *testing.T) {

--- a/pkg/fftypes/sizeutils.go
+++ b/pkg/fftypes/sizeutils.go
@@ -30,7 +30,7 @@ func ParseToByteSize(byteString string) int64 {
 	}
 	bytes, err := units.RAMInBytes(byteString)
 	if err != nil {
-		log.L(context.Background()).Warn(err.Error())
+		log.L(context.Background()).Warn(err)
 		return 0
 	}
 	return bytes

--- a/pkg/fftypes/subscription_test.go
+++ b/pkg/fftypes/subscription_test.go
@@ -52,6 +52,6 @@ func TestSubscriptionOptionsDatabaseSerialization(t *testing.T) {
 
 	// Out of luck with anything else
 	err = sub2.Options.Scan(false)
-	assert.Regexp(t, "FF10125", err.Error())
+	assert.Regexp(t, "FF10125", err)
 
 }

--- a/pkg/fftypes/timeutils.go
+++ b/pkg/fftypes/timeutils.go
@@ -151,7 +151,7 @@ func ParseToDuration(durationString string) time.Duration {
 	}
 	ffd, err := ParseDurationString(durationString)
 	if err != nil {
-		log.L(context.Background()).Warn(err.Error())
+		log.L(context.Background()).Warn(err)
 	}
 	return time.Duration(ffd)
 }

--- a/pkg/fftypes/timeutils_test.go
+++ b/pkg/fftypes/timeutils_test.go
@@ -71,7 +71,7 @@ func TestFFTimeJSONSerialization(t *testing.T) {
 func TestFFTimeJSONUnmarshalFail(t *testing.T) {
 	var utTimeTest UTTimeTest
 	err := json.Unmarshal([]byte(`{"t1": "!Badness"}`), &utTimeTest)
-	assert.Regexp(t, "FF10165", err.Error())
+	assert.Regexp(t, "FF10165", err)
 }
 
 func TestFFTimeDatabaseSerialization(t *testing.T) {
@@ -139,7 +139,7 @@ func TestFFTimeParseValue(t *testing.T) {
 
 	// A bad string
 	err = ft.Scan("!a supported time format")
-	assert.Regexp(t, "FF10165", err.Error())
+	assert.Regexp(t, "FF10165", err)
 
 	// Nil
 	err = ft.Scan(nil)
@@ -158,7 +158,7 @@ func TestFFTimeParseValue(t *testing.T) {
 
 	// A bad type
 	err = ft.Scan(false)
-	assert.Regexp(t, "FF10125", err.Error())
+	assert.Regexp(t, "FF10125", err)
 
 }
 
@@ -226,10 +226,10 @@ func TestFFDurationParseValue(t *testing.T) {
 	assert.Equal(t, FFDuration(12345)*FFDuration(time.Millisecond), fd)
 
 	err = fd.Scan(false)
-	assert.Regexp(t, "FF10125", err.Error())
+	assert.Regexp(t, "FF10125", err)
 
 	err = fd.Scan("1 year")
-	assert.Regexp(t, "FF10167", err.Error())
+	assert.Regexp(t, "FF10167", err)
 
 	var pfd *FFDuration
 	v, err := pfd.Value()

--- a/pkg/fftypes/validations_test.go
+++ b/pkg/fftypes/validations_test.go
@@ -26,23 +26,23 @@ import (
 func TestValidateFFNameField(t *testing.T) {
 
 	err := ValidateFFNameField(context.Background(), "_badstart", "badField")
-	assert.Regexp(t, "FF10131.*badField", err.Error())
+	assert.Regexp(t, "FF10131.*badField", err)
 
 	err = ValidateFFNameField(context.Background(), "badend_", "badField")
-	assert.Regexp(t, "FF10131.*badField", err.Error())
+	assert.Regexp(t, "FF10131.*badField", err)
 
 	err = ValidateFFNameField(context.Background(), "0123456789_123456789-123456789.123456789-123456789_1234567890123", "badField")
 	assert.NoError(t, err)
 
 	err = ValidateFFNameField(context.Background(), "0123456789_123456789-123456789.123456789-123456789_12345678901234", "badField")
-	assert.Regexp(t, "FF10131.*badField", err.Error())
+	assert.Regexp(t, "FF10131.*badField", err)
 
 }
 
 func TestValidateLength(t *testing.T) {
 
 	err := ValidateLength(context.Background(), "long string", "test", 5)
-	assert.Regexp(t, "FF10188.*test", err.Error())
+	assert.Regexp(t, "FF10188.*test", err)
 
 	err = ValidateLength(context.Background(), "short string", "test", 50)
 	assert.NoError(t, err)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,3 +1,19 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package e2e
 
 import (

--- a/test/e2e/restclient.go
+++ b/test/e2e/restclient.go
@@ -1,3 +1,19 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package e2e
 
 import (
@@ -29,7 +45,23 @@ func BroadcastDatatype(client *resty.Client, name string) (*resty.Response, erro
 					"property1": {
 						"type": "string"
 					}
-				}
+				}// Copyright © 2021 Kaleido, Inc.
+				//
+				// SPDX-License-Identifier: Apache-2.0
+				//
+				// Licensed under the Apache License, Version 2.0 (the "License");
+				// you may not use this file except in compliance with the License.
+				// You may obtain a copy of the License at
+				//
+				//     http://www.apache.org/licenses/LICENSE-2.0
+				//
+				// Unless required by applicable law or agreed to in writing, software
+				// distributed under the License is distributed on an "AS IS" BASIS,
+				// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+				// See the License for the specific language governing permissions and
+				// limitations under the License.
+				
+				
 			}`),
 		}).Post(urlBroadcastDatatype)
 }

--- a/test/e2e/stack.go
+++ b/test/e2e/stack.go
@@ -1,3 +1,19 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package e2e
 
 import (


### PR DESCRIPTION
- New `MessageInvalid` event type designating a message that's been rejected because the data was invalid, but is not blocking the context because we received all the data.
  - This means a message will not have a `confirmed` timestamp
- The aggregator now gets the full data, and passes it to the validation
  - This removes the need for the previous `CheckDataAvailable` function
  - The data manager is now always responsible for getting the data

In PR chain with #34