### PR TITLE
Minor Docker build optimizations

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 **/node_modules
 **/coverage
 **/.nyc_output
+solidity_firefly/build
 .git
 firefly

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.16-alpine3.13 AS firefly-builder
+RUN apk add make gcc build-base
 WORKDIR /firefly
 ADD . .
-RUN apk add make gcc build-base
 RUN make
 WORKDIR /firefly/solidity_firefly
 


### PR DESCRIPTION
Move tool installs before local builds, and add Solidity build
output to .dockerignore.