### PR TITLE
Helm Chart for FireFly

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - .github/workflows/helm.yml
-      - deploy/charts/**/*
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches:
       - main
-
+    paths-ignore:
+      - .github/workflows/helm.yml
+      - deploy/charts/**/*
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,8 +3,14 @@ name: Go
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - .github/workflows/helm.yml
+      - deploy/charts/**/*
   pull_request:
     branches: [main]
+    paths-ignore:
+      - .github/workflows/helm.yml
+      - deploy/charts/**/*
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,14 +3,8 @@ name: Go
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - .github/workflows/helm.yml
-      - deploy/charts/**/*
   pull_request:
     branches: [main]
-    paths-ignore:
-      - .github/workflows/helm.yml
-      - deploy/charts/**/*
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -42,8 +42,5 @@ jobs:
           helm repo add bitnami https://bitnami.io || true
           helm install --set postgresPassword=firef1y --set extraEnv[0].name=POSTGRES_DATABASE --set extraEnv[0].value=firefly postgresql bitnami/postgresql
 
-      - name: lint charts
-        run: ct lint --charts deploy/charts/firefly
-
       - name: test charts
-        run: ct install --charts deploy/charts/firefly
+        run: ct lint-and-install --charts deploy/charts/firefly

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,48 @@
+name: Helm
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "deploy/charts/**/*"
+jobs:
+  helm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: setup helm
+        uses: azure/setup-helm@v1
+
+      - name: setup chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+
+#      - name: Run chart-testing (list-changed)
+#        id: list-changed
+#        run: |
+#          changed=$(ct list-changed)
+#          if [[ -n "$changed" ]]; then
+#            echo "::set-output name=changed::true"
+#          fi
+
+#      - name: chart deps
+#        run: |
+#          helm repo add bitnami https://charts.bitnami.com/bitnami
+
+      - name: lint charts
+        run: ct lint --charts deploy/charts/firefly
+
+      - name: setup kind
+        uses: engineerd/setup-kind@v0.5.0
+
+      - name: install cert-manager for testing
+        run: |
+          kubectl create ns cert-manager || true
+          kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.crds.yaml
+          helm repo add jetstack https://charts.jetstack.io || true
+          helm install --skip-crds -n cert-manager jetstack/cert-manager
+          kubectl apply -n cert-manager -f deploy/manifests/tls-issuers.yaml
+
+      - name: test charts
+        run: ct install --charts deploy/charts/firefly

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -33,9 +33,14 @@ jobs:
         run: |
           kubectl create ns cert-manager || true
           kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.crds.yaml
-          helm repo add jetstack https://charts.jetstack.io || true
-          helm install --skip-crds -n cert-manager cert-manager jetstack/cert-manager --wait
           kubectl apply -n cert-manager -f deploy/manifests/tls-issuers.yaml
+          helm repo add jetstack https://charts.jetstack.io || true
+          helm install --skip-crds -n cert-manager cert-manager jetstack/cert-manager
+
+      - name: install postgres for testing
+        run: |
+          helm repo add bitnami https://bitnami.io || true
+          helm install --set postgresPassword=firef1y --set extraEnv[0].name=POSTGRES_DATABASE --set extraEnv[0].value=firefly postgresql bitnami/postgresql
 
       - name: lint charts
         run: ct lint --charts deploy/charts/firefly

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: setup kind
         uses: engineerd/setup-kind@v0.5.0
+        with:
+          version: v0.11.1
 
       - name: install cert-manager for testing
         run: |

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -38,7 +38,7 @@ jobs:
           kubectl create ns cert-manager || true
           kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.crds.yaml
           helm repo add jetstack https://charts.jetstack.io || true
-          helm install --skip-crds -n cert-manager --set cainjector.enabled=false cert-manager jetstack/cert-manager --wait
+          helm install --skip-crds -n cert-manager cert-manager jetstack/cert-manager --wait
           kubectl apply -n cert-manager -f deploy/manifests/tls-issuers.yaml
 
       - name: install postgres for testing

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -26,13 +26,6 @@ jobs:
 #            echo "::set-output name=changed::true"
 #          fi
 
-#      - name: chart deps
-#        run: |
-#          helm repo add bitnami https://charts.bitnami.com/bitnami
-
-      - name: lint charts
-        run: ct lint --charts deploy/charts/firefly
-
       - name: setup kind
         uses: engineerd/setup-kind@v0.5.0
 
@@ -43,6 +36,9 @@ jobs:
           helm repo add jetstack https://charts.jetstack.io || true
           helm install --skip-crds -n cert-manager jetstack/cert-manager
           kubectl apply -n cert-manager -f deploy/manifests/tls-issuers.yaml
+
+      - name: lint charts
+        run: ct lint --charts deploy/charts/firefly
 
       - name: test charts
         run: ct install --charts deploy/charts/firefly

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: install postgres for testing
         run: |
-          helm repo add bitnami https://charts.bitnami.com || true
+          helm repo add bitnami https://charts.bitnami.com/bitnami || true
           helm install --set postgresPassword=firef1y --set extraEnv[0].name=POSTGRES_DATABASE --set extraEnv[0].value=firefly postgresql bitnami/postgresql
 
       - name: debug k8s

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -34,7 +34,7 @@ jobs:
           kubectl create ns cert-manager || true
           kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.crds.yaml
           helm repo add jetstack https://charts.jetstack.io || true
-          helm install --skip-crds -n cert-manager cert-manager jetstack/cert-manager
+          helm install --skip-crds -n cert-manager cert-manager jetstack/cert-manager --wait
           kubectl apply -n cert-manager -f deploy/manifests/tls-issuers.yaml
 
       - name: lint charts

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -34,7 +34,7 @@ jobs:
           kubectl create ns cert-manager || true
           kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.crds.yaml
           helm repo add jetstack https://charts.jetstack.io || true
-          helm install --skip-crds -n cert-manager jetstack/cert-manager
+          helm install --skip-crds -n cert-manager cert-manager jetstack/cert-manager
           kubectl apply -n cert-manager -f deploy/manifests/tls-issuers.yaml
 
       - name: lint charts

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -14,6 +14,8 @@ jobs:
 
       - name: setup helm
         uses: azure/setup-helm@v1
+        with:
+          version: 3.6.0
 
       - name: setup chart-testing
         uses: helm/chart-testing-action@v2.0.1
@@ -33,14 +35,19 @@ jobs:
         run: |
           kubectl create ns cert-manager || true
           kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.crds.yaml
-          kubectl apply -n cert-manager -f deploy/manifests/tls-issuers.yaml
           helm repo add jetstack https://charts.jetstack.io || true
-          helm install --skip-crds -n cert-manager --set cainjector.enabled=false cert-manager jetstack/cert-manager
+          helm install --skip-crds -n cert-manager --set cainjector.enabled=false cert-manager jetstack/cert-manager --wait
+          kubectl apply -n cert-manager -f deploy/manifests/tls-issuers.yaml
 
       - name: install postgres for testing
         run: |
           helm repo add bitnami https://charts.bitnami.com || true
           helm install --set postgresPassword=firef1y --set extraEnv[0].name=POSTGRES_DATABASE --set extraEnv[0].value=firefly postgresql bitnami/postgresql
+
+      - name: debug k8s
+        if: always()
+        run: |
+          kubectl get pod -A
 
       - name: test charts
         run: ct lint-and-install --charts deploy/charts/firefly

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -35,11 +35,11 @@ jobs:
           kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.crds.yaml
           kubectl apply -n cert-manager -f deploy/manifests/tls-issuers.yaml
           helm repo add jetstack https://charts.jetstack.io || true
-          helm install --skip-crds -n cert-manager cert-manager jetstack/cert-manager
+          helm install --skip-crds -n cert-manager --set cainjector.enabled=false cert-manager jetstack/cert-manager
 
       - name: install postgres for testing
         run: |
-          helm repo add bitnami https://bitnami.io || true
+          helm repo add bitnami https://charts.bitnami.com || true
           helm install --set postgresPassword=firef1y --set extraEnv[0].name=POSTGRES_DATABASE --set extraEnv[0].value=firefly postgresql bitnami/postgresql
 
       - name: test charts

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ coverage.txt
 .DS_Store
 frontend
 __debug*
+!deploy/charts/firefly

--- a/deploy/charts/firefly/.helmignore
+++ b/deploy/charts/firefly/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+ci/

--- a/deploy/charts/firefly/Chart.yaml
+++ b/deploy/charts/firefly/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: firefly
+description: A Helm chart for Kubernetes
+type: application
+# TODO appVersion and version might be the same once an official FireFly release is made
+appVersion: "0.0.1"
+version: "0.0.1"
+
+maintainers:
+  - name: hfuss
+    email: hayden.fuss@kaleido.io

--- a/deploy/charts/firefly/README.md
+++ b/deploy/charts/firefly/README.md
@@ -1,0 +1,46 @@
+# FireFly
+
+A bare-bones Helm chart for installing a [FireFly](https://github.com/hyperledger-labs/firefly) node with robust templating of its configuration
+for development and production scenarios. Additionally, includes FireFly's [default DataExchange](https://github.com/hyperledger-labs/firefly-dataexchange-https) component
+for simple, private messaging using HTTPS backed with mTLS.
+
+## TL;DR
+
+```shell
+# Deploy a FireFly node w/ some dummy values
+$ helm install acme-firefly ./deploy/charts/firefly \
+  --set dataexchange.tlsSecret.name=acme-dx-tls \
+  --set config.organizationName=acme \
+  --set config.organizationIdentity="0xeb7284ce905e0665b7d42cabe31c76c45da1d331" \
+  --set config.fireflyContractAddress="0xeb7284ce905e0665b7d42cabe31c76c45da1d254"
+```
+
+> **Note**: FireFly requires additional configuration for its blockchain, database, and public storage in order to be fully functional. See [example-values.yaml](./ci/example-values.yaml) for an example, and below for more details.
+
+## Introduction
+
+
+
+## Prerequisites
+
+* Kubernetes 1.14+
+* Helm 3.6.0
+* PV provisioner support in the underlying infrastructure
+
+## Installing the Chart
+
+```shell
+
+```
+
+## Uninstalling the Chart
+
+```shell
+
+```
+
+## Parameters
+
+| Parameter                                     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Default                                                       |
+|-----------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|
+| `config.debugEnabled` | Enables the FireFly debug port on 6060 and `DEBUG` level logs. | `false` |

--- a/deploy/charts/firefly/README.md
+++ b/deploy/charts/firefly/README.md
@@ -15,7 +15,7 @@ $ helm install acme-firefly ./deploy/charts/firefly \
   --set config.fireflyContractAddress="0xeb7284ce905e0665b7d42cabe31c76c45da1d254"
 ```
 
-> **Note**: FireFly requires additional configuration for its blockchain, database, and public storage in order to be fully functional. See [example-values.yaml](./ci/example-values.yaml) for an example, and below for more details.
+> **Note**: FireFly requires additional configuration for its blockchain, database, and public storage in order to be fully functional. See [example-values.yaml](ci/it-values.yaml) for an example, and below for more details.
 
 ## Introduction
 

--- a/deploy/charts/firefly/ci/example-values.yaml
+++ b/deploy/charts/firefly/ci/example-values.yaml
@@ -1,0 +1,25 @@
+config:
+  debugEnabled: true
+  adminEnabled: true
+  preInit: true
+
+  organizationName: "acme"
+  organizationIdentity: "0xeb7284ce905e0665b7d42cabe31c76c45da1d331"
+  fireflyContractAddress: "0xeb7284ce905e0665b7d42cabe31c76c45da1d254"
+
+  ethconnectUrl: "http://ethconnect.acme.org"
+
+  postgresUrl: "postgres://postgres:firef1y@psql.acme.org:5432"
+
+  ipfsApiUrl: "http://ipfs.acme.org:5001"
+  ipfsGatewayUrl: "http://ipfs.acme.org:8080"
+
+dataexchange:
+  certificate:
+    enabled: true
+    issuerRef:
+      kind: ClusterIssuer
+      name: selfsigned-ca
+
+  tlsSecret:
+    enabled: false

--- a/deploy/charts/firefly/ci/example-values.yaml
+++ b/deploy/charts/firefly/ci/example-values.yaml
@@ -1,18 +1,18 @@
 config:
   debugEnabled: true
   adminEnabled: true
-  preInit: true
+  preInit: false
 
-  organizationName: "acme"
+  organizationName: "firefly-os"
   organizationIdentity: "0xeb7284ce905e0665b7d42cabe31c76c45da1d331"
   fireflyContractAddress: "0xeb7284ce905e0665b7d42cabe31c76c45da1d254"
 
-  ethconnectUrl: "http://ethconnect.acme.org"
+  ethconnectUrl: "http://ethconnect.firefly-os"
 
-  postgresUrl: "postgres://postgres:firef1y@psql.acme.org:5432"
+  postgresUrl: "postgres://postgres:firef1y@psql.firefly-os:5432"
 
-  ipfsApiUrl: "http://ipfs.acme.org:5001"
-  ipfsGatewayUrl: "http://ipfs.acme.org:8080"
+  ipfsApiUrl: "http://ipfs.firefly-os:5001"
+  ipfsGatewayUrl: "http://ipfs.firefly-os:8080"
 
 dataexchange:
   certificate:

--- a/deploy/charts/firefly/ci/it-values.yaml
+++ b/deploy/charts/firefly/ci/it-values.yaml
@@ -9,7 +9,7 @@ config:
 
   ethconnectUrl: "http://ethconnect.firefly-os"
 
-  postgresUrl: "postgres://postgres:firef1y@psql.firefly-os:5432"
+  postgresUrl: "postgres://postgres:firef1y@postgresql:5432?sslmode=disable"
 
   ipfsApiUrl: "http://ipfs.firefly-os:5001"
   ipfsGatewayUrl: "http://ipfs.firefly-os:8080"

--- a/deploy/charts/firefly/templates/NOTES.txt
+++ b/deploy/charts/firefly/templates/NOTES.txt
@@ -1,0 +1,22 @@
+{{/*1. Get the application URL by running these commands:*/}}
+{{/*{{- if .Values.ingress.enabled }}*/}}
+{{/*{{- range $host := .Values.ingress.hosts }}*/}}
+{{/*  {{- range .paths }}*/}}
+{{/*  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}*/}}
+{{/*  {{- end }}*/}}
+{{/*{{- end }}*/}}
+{{/*{{- else if contains "NodePort" .Values.service.type }}*/}}
+{{/*  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "firefly.fullname" . }})*/}}
+{{/*  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")*/}}
+{{/*  echo http://$NODE_IP:$NODE_PORT*/}}
+{{/*{{- else if contains "LoadBalancer" .Values.service.type }}*/}}
+{{/*     NOTE: It may take a few minutes for the LoadBalancer IP to be available.*/}}
+{{/*           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "firefly.fullname" . }}'*/}}
+{{/*  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "firefly.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")*/}}
+{{/*  echo http://$SERVICE_IP:{{ .Values.service.port }}*/}}
+{{/*{{- else if contains "ClusterIP" .Values.service.type }}*/}}
+{{/*  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "firefly.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")*/}}
+{{/*  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")*/}}
+{{/*  echo "Visit http://127.0.0.1:8080 to use your application"*/}}
+{{/*  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT*/}}
+{{/*{{- end }}*/}}

--- a/deploy/charts/firefly/templates/_helpers.tpl
+++ b/deploy/charts/firefly/templates/_helpers.tpl
@@ -1,0 +1,70 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "firefly.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "firefly.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "firefly.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "firefly.labels" -}}
+helm.sh/chart: {{ include "firefly.chart" . }}
+{{ include "firefly.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "firefly.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "firefly.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "firefly.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "firefly.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "firefly.dataexchangeP2PHost" -}}
+{{- if .Values.dataexchange.ingress.enabled }}
+{{- index .Values.dataexchange.ingress.hosts 0 }}
+{{- else }}
+{{- printf "%s-dx:%d" (include "firefly.fullname" .) (.Values.dataexchange.service.p2pPort | int64) }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/firefly/templates/core/ingress.yaml
+++ b/deploy/charts/firefly/templates/core/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.core.ingress.enabled -}}
+{{- $fullName := include "firefly.fullname" . -}}
+{{- $svcPort := .Values.core.service.httpPort -}}
+{{- if and .Values.core.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.core.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.core.ingress.annotations "kubernetes.io/ingress.class" .Values.core.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "firefly.labels" . | nindent 4 }}
+  {{- with .Values.core.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.core.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.core.ingress.className }}
+  {{- end }}
+  {{- if .Values.core.ingress.tls }}
+  tls:
+    {{- range .Values.core.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.core.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/charts/firefly/templates/core/secret.yaml
+++ b/deploy/charts/firefly/templates/core/secret.yaml
@@ -1,0 +1,77 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "firefly.fullname" . }}-config
+  labels:
+  {{- include "firefly.labels" . | nindent 4 }}
+stringData:
+  firefly.core: |
+    {{- if .Values.config.debugEnabled }}
+    log:
+      level: debug
+    debug:
+      port: 6060
+    {{- end }}
+    http:
+      port: 5000
+      address: 0.0.0.0
+    admin:
+      port: 5001
+      address: 0.0.0.0
+      enabled: {{ .Values.config.adminEnabled }}
+      preinit: {{ and .Values.config.adminEnabled .Values.config.preInit }}
+    ui:
+      path: ./frontend
+    node:
+      name: {{ .Values.config.organizationName }}-{{ include "firefly.fullname" . }}
+    org:
+      name: {{ .Values.config.organizationName }}
+      identity: {{ .Values.config.organizationIdentity }}
+    {{- if .Values.config.blockchain }}
+    blockchain:
+      {{- toYaml (tpl .Values.config.blockchain .) | nindent 6 }}
+    {{- else if .Values.config.ethconnectUrl }}
+    blockchain:
+      type: ethereum
+      ethereum:
+        ethconnect:
+          url: {{ tpl .Values.config.ethconnectUrl . }}
+          instance: {{ .Values.config.fireflyContractAddress }}
+          topic: "0" # TODO should likely be configurable
+    {{- end }}
+    {{- if .Values.config.database }}
+    database:
+      {{- toYaml (tpl .Values.config.database .) | nindent 6 }}
+    {{- else if .Values.config.postgresUrl }}
+    database:
+      type: postgres
+      postgres:
+        url: {{ tpl .Values.config.postgresUrl . }}
+        migrations:
+          auto: {{ .Values.config.postgresAutomigrate }}
+    {{- end }}
+    {{- if .Values.config.publicstorage }}
+    publicstorage:
+      {{- toYaml (tpl .Values.config.publicstorage .) | nindent 6 }}
+    {{- else if and .Values.config.ipfsApiUrl .Values.config.ipfsGatewayUrl }}
+    publicstorage:
+      type: ipfs
+      ipfs:
+        api:
+          url: {{ tpl .Values.config.ipfsApiUrl . }}
+        gateway:
+          url: {{ tpl .Values.config.ipfsGatewayUrl . }}
+        {{- end }}
+    {{- if and .Values.config.dataexchange (not .Values.dataexchange.enabled) }}
+    dataexchange:
+      {{- toYaml (tpl .Values.config.dataexchange .) | nindent 6 }}
+    {{- else }}
+    dataexchange:
+      {{- if .Values.dataexchange.enabled }}
+      https:
+        url: http://{{ include "firefly.fullname" . }}-dx:{{ .Values.dataexchange.service.apiPort }}
+      {{- else }}
+      https:
+        url: {{ tpl .Values.config.dataexchangeUrl . }}
+      {{- end }}
+    {{- end }}

--- a/deploy/charts/firefly/templates/core/service.yaml
+++ b/deploy/charts/firefly/templates/core/service.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "firefly.fullname" . }}
+  labels:
+    {{- include "firefly.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.core.service.type }}
+  clusterIP: None
+  ports:
+    {{- if .Values.config.debugEnabled }}
+    - port: {{ .Values.core.service.debugPort }}
+      targetPort: debug
+      protocol: TCP
+      name: debug
+    {{- end }}
+    - port: {{ .Values.core.service.httpPort }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    {{- if .Values.config.adminEnabled }}
+    - port: {{ .Values.core.service.adminPort }}
+      targetPort: admin
+      protocol: TCP
+      name: admin
+    {{- end }}
+  selector:
+    {{- include "firefly.selectorLabels" . | nindent 4 }}

--- a/deploy/charts/firefly/templates/core/statefulset.yaml
+++ b/deploy/charts/firefly/templates/core/statefulset.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "firefly.fullname" . }}
+  labels:
+    {{- include "firefly.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "firefly.fullname" . }}
+  updateStrategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "firefly.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/core/secret.yaml") . | sha256sum }}
+        {{- with .Values.core.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "firefly.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.core.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.core.podSecurityContext | nindent 8 }}
+{{/*      initContainers:*/}}
+{{/*        - name: psql-ready*/}}
+{{/*          image: "{{ .Values.postgresql.image.registry }}/{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"*/}}
+{{/*          imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}*/}}
+{{/*          command:*/}}
+{{/*            - sh*/}}
+{{/*            - -c*/}}
+{{/*            {{- if .Values.postgresql.enabled }}*/}}
+{{/*            - 'until pg_isready -h {{ .Values.postgresql.fullnameOverride }} -p 5432; do echo "waiting for database"; sleep 2; done;'*/}}
+{{/*            {{- else }}*/}}
+{{/*            - 'until pg_isready -h {{ .Values.config.postgresHostname }} -p {{ .Values.config.postgresPort }}; do echo "waiting for database"; sleep 2; done;'*/}}
+{{/*            {{- end }}*/}}
+      containers:
+        - name: firefly
+          securityContext:
+            {{- toYaml .Values.core.securityContext | nindent 12 }}
+          image: "{{ .Values.core.image.repository }}:{{ .Values.core.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.core.image.pullPolicy }}
+          ports:
+            {{- if .Values.config.debugEnabled }}
+            - name: debug
+              containerPort: 6060
+              protocol: TCP
+            {{- end }}
+            - name: http
+              containerPort: 5000
+              protocol: TCP
+            {{- if .Values.config.adminEnabled }}
+            - name: admin
+              containerPort: 5001
+              protocol: TCP
+            {{- end }}
+{{/*          livenessProbe:*/}}
+{{/*            httpGet:*/}}
+{{/*              path: /*/}}
+{{/*              port: http*/}}
+{{/*          readinessProbe:*/}}
+{{/*            httpGet:*/}}
+{{/*              path: /*/}}
+{{/*              port: http*/}}
+          volumeMounts:
+            - mountPath: /etc/firefly/
+              name: firefly-config
+          resources:
+            {{- toYaml .Values.core.resources | nindent 12 }}
+      {{- with .Values.core.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.core.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.core.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: firefly-config
+          secret:
+            secretName: {{ include "firefly.fullname" . }}-config

--- a/deploy/charts/firefly/templates/dataexchange/certificate.yaml
+++ b/deploy/charts/firefly/templates/dataexchange/certificate.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.dataexchange.enabled .Values.dataexchange.certificate.enabled }}
+{{- if not (.Capabilities.APIVersions.Has "cert-manager.io/v1") }}
+{{- fail "dataexchange.certificate.enabled is true, however the required cert-manager APIs are not installed onto the cluster" }}
+{{- end }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: "{{ include "firefly.fullname" . }}-dx"
+  labels:
+    {{- include "firefly.labels" . | nindent 4 }}
+spec:
+  issuerRef:
+    {{- toYaml .Values.dataexchange.certificate.issuerRef | nindent 4 }}
+  secretName: "{{ include "firefly.fullname" . }}-dx-tls"
+  subject:
+    organizations:
+      - {{ .Values.config.organizationName }}
+  commonName: {{ include "firefly.fullname" . }}-dx
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    {{- if .Values.dataexchange.ingress.enabled }}
+    {{- range .Values.dataexchange.ingress.hosts }}
+    - {{ .host }}
+    {{- end }}
+    {{- else }}
+    - {{ include "firefly.fullname" . }}-dx
+    - {{ include "firefly.fullname" . }}-dx.{{ .Release.Namespace }}.svc
+    - {{ include "firefly.fullname" . }}-dx.{{ .Release.Namespace }}.svc.cluster.local
+    {{- end }}
+{{- end }}

--- a/deploy/charts/firefly/templates/dataexchange/ingress.yaml
+++ b/deploy/charts/firefly/templates/dataexchange/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if and .Values.dataexchange.enabled .Values.dataexchange.ingress.enabled -}}
+{{- $fullName := include "firefly.fullname" . -}}
+{{- $svcPort := .Values.dataexchange.service.apiPort -}}
+{{- if and .Values.dataexchange.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.dataexchange.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.dataexchange.ingress.annotations "kubernetes.io/ingress.class" .Values.dataexchange.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-dx
+  labels:
+    {{- include "firefly.labels" . | nindent 4 }}
+  {{- with .Values.dataexchange.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.dataexchange.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.dataexchange.ingress.className }}
+  {{- end }}
+  {{- if .Values.dataexchange.ingress.tls }}
+  tls:
+    {{- range .Values.dataexchange.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.dataexchange.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}-dx
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}-dx
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/charts/firefly/templates/dataexchange/secret.yaml
+++ b/deploy/charts/firefly/templates/dataexchange/secret.yaml
@@ -17,6 +17,9 @@ stringData:
         "port": 3001,
         "endpoint": "https://{{ include "firefly.dataexchangeP2PHost" . }}"
       },
-      "peers": {{ toJson .Values.dataexchange.peers }}
+      {{- if .Values.dataexchange.apiKey }}
+      "apiKey": {{ .Values.dataexchange.apiKey | quote }}
+      {{- end }}
+      "peers": []
     }
 {{- end }}

--- a/deploy/charts/firefly/templates/dataexchange/secret.yaml
+++ b/deploy/charts/firefly/templates/dataexchange/secret.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.dataexchange.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "firefly.fullname" . }}-dx-config
+  labels:
+  {{- include "firefly.labels" . | nindent 4 }}
+stringData:
+  config.json: |
+    {
+      "api": {
+        "hostname": "0.0.0.0",
+        "port": 3000
+      },
+      "p2p": {
+        "hostname": "0.0.0.0",
+        "port": 3001,
+        "endpoint": "https://{{ include "firefly.dataexchangeP2PHost" . }}"
+      },
+      "peers": {{ toJson .Values.dataexchange.peers }}
+    }
+{{- end }}

--- a/deploy/charts/firefly/templates/dataexchange/service.yaml
+++ b/deploy/charts/firefly/templates/dataexchange/service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.dataexchange.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "firefly.fullname" . }}-dx
+  labels:
+    {{- include "firefly.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.dataexchange.service.type }}
+  clusterIP: None
+  ports:
+    - port: {{ .Values.dataexchange.service.apiPort }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: {{ .Values.dataexchange.service.p2pPort }}
+      targetPort: p2p
+      protocol: TCP
+      name: p2p
+  selector:
+    {{- include "firefly.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/deploy/charts/firefly/templates/dataexchange/statefulset.yaml
+++ b/deploy/charts/firefly/templates/dataexchange/statefulset.yaml
@@ -1,0 +1,101 @@
+{{- if .Values.dataexchange.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "firefly.fullname" . }}-dx
+  labels:
+    {{- include "firefly.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  serviceName: {{ include "firefly.fullname" . }}-dx
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      {{- include "firefly.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/dataexchange/secret.yaml") . | sha256sum }}
+        {{- if .Values.dataexchange.certificate.enabled }}
+        checksum/certificate: {{ include (print $.Template.BasePath "/dataexchange/certificate.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.dataexchange.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "firefly.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.dataexchange.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.dataexchange.podSecurityContext | nindent 8 }}
+      containers:
+        - name: dx
+          securityContext:
+            {{- toYaml .Values.dataexchange.securityContext | nindent 12 }}
+          image: "{{ .Values.dataexchange.image.repository }}:{{ .Values.dataexchange.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.dataexchange.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+            - name: p2p
+              containerPort: 3001
+              protocol: TCP
+{{/*          livenessProbe:*/}}
+{{/*            httpGet:*/}}
+{{/*              path: /*/}}
+{{/*              port: http*/}}
+{{/*          readinessProbe:*/}}
+{{/*            httpGet:*/}}
+{{/*              path: /*/}}
+{{/*              port: http*/}}
+          resources:
+            {{- toYaml .Values.dataexchange.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /data/peer-certs
+              name: {{ include "firefly.fullname" . }}-dx-peer-certs
+            - mountPath: /data/config.json
+              name: config
+              subPath: config.json
+            - mountPath: /data/key.pem
+              name: tls
+              subPath: tls.key
+            - mountPath: /data/cert.pem
+              name: tls
+              subPath: tls.crt
+            - mountPath: /data/ca.pem
+              name: tls
+              subPath: ca.crt
+      {{- with .Values.dataexchange.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dataexchange.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dataexchange.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          secret:
+            secretName: "{{ include "firefly.fullname" . }}-dx-config"
+        - name: tls
+          secret:
+            secretName: {{ if and .Values.dataexchange.certificate.enabled (not .Values.dataexchange.tlsSecret.enabled) }}"{{ include "firefly.fullname" . }}-dx-tls"{{ else }}{{ .Values.dataexchange.tlsSecret.name }}{{ end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ include "firefly.fullname" . }}-dx-peer-certs
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+{{- end }}

--- a/deploy/charts/firefly/templates/dataexchange/statefulset.yaml
+++ b/deploy/charts/firefly/templates/dataexchange/statefulset.yaml
@@ -58,6 +58,8 @@ spec:
           volumeMounts:
             - mountPath: /data/peer-certs
               name: {{ include "firefly.fullname" . }}-dx-peer-certs
+            - mountPath: /data/peers
+              name: {{ include "firefly.fullname" . }}-dx-peers
             - mountPath: /data/config.json
               name: config
               subPath: config.json
@@ -92,6 +94,14 @@ spec:
   volumeClaimTemplates:
     - metadata:
         name: {{ include "firefly.fullname" . }}-dx-peer-certs
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+    - metadata:
+        name: {{ include "firefly.fullname" . }}-dx-peers
       spec:
         accessModes:
           - ReadWriteOnce

--- a/deploy/charts/firefly/templates/tests/test-connection.yaml
+++ b/deploy/charts/firefly/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+{{/*apiVersion: v1*/}}
+{{/*kind: Pod*/}}
+{{/*metadata:*/}}
+{{/*  name: "{{ include "firefly.fullname" . }}-test-connection"*/}}
+{{/*  labels:*/}}
+{{/*    {{- include "firefly.labels" . | nindent 4 }}*/}}
+{{/*  annotations:*/}}
+{{/*    "helm.sh/hook": test*/}}
+{{/*spec:*/}}
+{{/*  containers:*/}}
+{{/*    - name: wget*/}}
+{{/*      image: busybox*/}}
+{{/*      command: ['wget']*/}}
+{{/*      args: ['{{ include "firefly.fullname" . }}:{{ .Values.service.port }}']*/}}
+{{/*  restartPolicy: Never*/}}

--- a/deploy/charts/firefly/values.yaml
+++ b/deploy/charts/firefly/values.yaml
@@ -118,10 +118,6 @@ dataexchange:
     enabled: true
     name: ""
 
-  # TODO should config.json be persistable / writeable?
-  peers: []
-   # - "https://another-org-dataexchange-0.another.org"
-
   image:
     repository: ghcr.io/hyperledger-labs/firefly-dataexchange-https
     pullPolicy: Always

--- a/deploy/charts/firefly/values.yaml
+++ b/deploy/charts/firefly/values.yaml
@@ -1,0 +1,185 @@
+# Templates the firefly.core configuration file of FireFly, and in some cases configures which ports are exposed.
+config:
+
+  # Enables the FireFly debug port on 6060 and `DEBUG` level logs
+  debugEnabled: false
+
+  # Enables the Admin API for dynamic configuration
+  adminEnabled: false
+
+  # Puts a fresh FireFly node into the preinit state, allowing an operator to then setup smart contracts, apply database migrations, etc. before re-configuring the node to proceed.
+  # It is _not_ recommended to configure FireFly nodes in a preinit state for non-development scenarios.
+  preInit: false
+
+  organizationName: ""
+  organizationIdentity: ""
+  fireflyContractAddress: ""
+
+  # used for more open ended configuration of firefly core i.e. future plugins, production scenarios, etc.
+  dataexchange: {}
+
+  database: {}
+
+  publicstorage: {}
+
+  blockchain: {}
+   # type: ethereum
+   # ethereum:
+   #   ethconnect:
+   #     url: http://ethconnect_0:8080
+   #     instance: /contracts/firefly
+   #     topic: "0"
+
+  postgresUrl: ""
+  postgresAutomigrate: false
+
+  dataexchangeUrl: ""
+
+  #
+  ipfsApiUrl: ""
+  ipfsGatewayUrl: ""
+
+  ethconnectUrl: ""
+
+core:
+  image:
+    repository: ghcr.io/hyperledger-labs/firefly
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: latest
+
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+    # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    httpPort: 5000
+    adminPort: 5001
+    debugPort: 6060
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    hosts:
+      - host: chart-example.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
+
+dataexchange:
+  enabled: true
+
+  certificate:
+    enabled: false
+    issuerRef: {}
+     # name: interal-ca
+     # kind: ClusterIssuer
+
+  tlsSecret:
+    enabled: true
+    name: ""
+
+  # TODO should config.json be persistable / writeable?
+  peers: []
+   # - "https://another-org-dataexchange-0.another.org"
+
+  image:
+    repository: ghcr.io/hyperledger-labs/firefly-dataexchange-https
+    pullPolicy: Always
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: latest
+
+  imagePullSecrets: []
+  nameOverride: ""
+  fullnameOverride: ""
+
+  podAnnotations: {}
+
+  podSecurityContext: {}
+  # fsGroup: 2000
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+  # runAsUser: 1000
+
+  service:
+    type: ClusterIP
+    apiPort: 5000
+    p2pPort: 5001
+
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    hosts:
+      - host: chart-example.local
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+  #   memory: 128Mi
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}

--- a/deploy/manifests/tls-issuers.yaml
+++ b/deploy/manifests/tls-issuers.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: selfsigned-ca
+spec:
+  issuerRef:
+    name: selfsigned
+    kind: ClusterIssuer
+  isCA: true
+  secretName: selfsigned-ca-tls
+  commonName: selfsigned-ca
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-ca
+spec:
+  ca:
+    secretName: selfsigned-ca-tls


### PR DESCRIPTION
Provides a simple Helm chart for deploying FireFly Core and DX. Features simple options for templating the `firefly.core` config as a `Secret`, as well as more open-ended overrides for future plugins, more complicated scenarios, etc.

DX can have mTLS certificate autogenerated and managed via [cert-manager](https://github.com/jetstack/cert-manager) for simplicity.

Includes a GHA workflow that uses [chart-testing](https://github.com/helm/chart-testing) and [KinD](https://kind.sigs.k8s.io/) for chart linting and "integration" testing i.e. do pods get installed and come up.

# TODOs
- [ ] Get integration test passing
- Follow-up Issues
  - [ ] Liveness / readiness probes
  - [ ] Proper chart packaging and releases via GH Pages
  - [ ] Open-ended question for docs / automation around blockchain initialization and contracts
  - [ ] Init containers for ensuring each plugin interface is up i.e. Postgres, ethconnect, dx, IPFS
- Docs
  - [ ] README.md
  - [ ] templates/NOTES.txt
  - [ ] Comments in values.yaml