### PR TITLE
GetConnectors endpoint

### DIFF
--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -5500,6 +5500,39 @@ paths:
           description: Success
         default:
           description: ""
+  /namespaces/{ns}/tokens/connectors:
+    get:
+      description: 'TODO: Description'
+      operationId: getTokenConnectors
+      parameters:
+      - description: 'TODO: Description'
+        in: path
+        name: ns
+        required: true
+        schema:
+          example: default
+          type: string
+      - description: Server-side request timeout (millseconds, or set a custom suffix
+          like 10s)
+        in: header
+        name: Request-Timeout
+        schema:
+          default: 120s
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                items:
+                  properties:
+                    name:
+                      type: string
+                  type: object
+                type: array
+          description: Success
+        default:
+          description: ""
   /namespaces/{ns}/transactions:
     get:
       description: 'TODO: Description'

--- a/internal/apiserver/route_get_token_connectors.go
+++ b/internal/apiserver/route_get_token_connectors.go
@@ -1,0 +1,44 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"net/http"
+
+	"github.com/hyperledger/firefly/internal/config"
+	"github.com/hyperledger/firefly/internal/i18n"
+	"github.com/hyperledger/firefly/internal/oapispec"
+	"github.com/hyperledger/firefly/pkg/fftypes"
+)
+
+var getTokenConnectors = &oapispec.Route{
+	Name:   "getTokenConnectors",
+	Path:   "namespaces/{ns}/tokens/connectors",
+	Method: http.MethodGet,
+	PathParams: []*oapispec.PathParam{
+		{Name: "ns", ExampleFromConf: config.NamespacesDefault, Description: i18n.MsgTBD},
+	},
+	QueryParams:     nil,
+	FilterFactory:   nil,
+	Description:     i18n.MsgTBD,
+	JSONInputValue:  nil,
+	JSONOutputValue: func() interface{} { return []*fftypes.TokenConnector{} },
+	JSONOutputCodes: []int{http.StatusOK},
+	JSONHandler: func(r *oapispec.APIRequest) (output interface{}, err error) {
+		return r.Or.Assets().GetTokenConnectors(r.Ctx, r.PP["ns"])
+	},
+}

--- a/internal/apiserver/route_get_token_connectors_test.go
+++ b/internal/apiserver/route_get_token_connectors_test.go
@@ -1,0 +1,42 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apiserver
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hyperledger/firefly/mocks/assetmocks"
+	"github.com/hyperledger/firefly/pkg/fftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestGetTokenConnectors(t *testing.T) {
+	o, r := newTestAPIServer()
+	mam := &assetmocks.Manager{}
+	o.On("Assets").Return(mam)
+	req := httptest.NewRequest("GET", "/api/v1/namespaces/ns1/tokens/connectors", nil)
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	res := httptest.NewRecorder()
+
+	mam.On("GetTokenConnectors", mock.Anything, "ns1", mock.Anything).
+		Return([]*fftypes.TokenConnector{}, nil)
+	r.ServeHTTP(res, req)
+
+	assert.Equal(t, 200, res.Result().StatusCode)
+}

--- a/internal/apiserver/routes.go
+++ b/internal/apiserver/routes.go
@@ -85,4 +85,5 @@ var routes = []*oapispec.Route{
 	postTokenMint,
 	postTokenBurn,
 	postTokenTransfer,
+	getTokenConnectors,
 }

--- a/internal/assets/manager.go
+++ b/internal/assets/manager.go
@@ -45,6 +45,7 @@ type Manager interface {
 	MintTokens(ctx context.Context, ns, typeName, poolName string, transfer *fftypes.TokenTransferInput, waitConfirm bool) (*fftypes.TokenTransfer, error)
 	BurnTokens(ctx context.Context, ns, typeName, poolName string, transfer *fftypes.TokenTransferInput, waitConfirm bool) (*fftypes.TokenTransfer, error)
 	TransferTokens(ctx context.Context, ns, typeName, poolName string, transfer *fftypes.TokenTransferInput, waitConfirm bool) (*fftypes.TokenTransfer, error)
+	GetTokenConnectors(ctx context.Context, ns string) ([]*fftypes.TokenConnector, error)
 
 	// Bound token callbacks
 	TokenPoolCreated(tk tokens.Plugin, pool *fftypes.TokenPool, protocolTxID string, additionalInfo fftypes.JSONObject) error
@@ -108,6 +109,24 @@ func (am *assetManager) GetTokenAccounts(ctx context.Context, ns, typeName, pool
 		return nil, nil, err
 	}
 	return am.database.GetTokenAccounts(ctx, filter.Condition(filter.Builder().Eq("poolprotocolid", pool.ProtocolID)))
+}
+
+func (am *assetManager) GetTokenConnectors(ctx context.Context, ns string) ([]*fftypes.TokenConnector, error) {
+	if err := fftypes.ValidateFFNameField(ctx, ns, "namespace"); err != nil {
+		return nil, err
+	}
+
+	connectors := []*fftypes.TokenConnector{}
+	for token := range am.tokens {
+		connectors = append(
+			connectors,
+			&fftypes.TokenConnector{
+				Name: token,
+			},
+		)
+	}
+
+	return connectors, nil
 }
 
 func (am *assetManager) Start() error {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -324,7 +324,8 @@ func (or *orchestrator) initPlugins(ctx context.Context) (err error) {
 
 	if or.tokens == nil {
 		or.tokens = make(map[string]tokens.Plugin)
-		for i := 0; i < tokensConfig.ArraySize(); i++ {
+		tokensConfigArraySize := tokensConfig.ArraySize()
+		for i := 0; i < tokensConfigArraySize; i++ {
 			prefix := tokensConfig.ArrayEntry(i)
 			name := prefix.GetString(tokens.TokensConfigName)
 			pluginName := prefix.GetString(tokens.TokensConfigPlugin)

--- a/mocks/assetmocks/manager.go
+++ b/mocks/assetmocks/manager.go
@@ -98,6 +98,29 @@ func (_m *Manager) GetTokenAccounts(ctx context.Context, ns string, typeName str
 	return r0, r1, r2
 }
 
+// GetTokenConnectors provides a mock function with given fields: ctx, ns
+func (_m *Manager) GetTokenConnectors(ctx context.Context, ns string) ([]*fftypes.TokenConnector, error) {
+	ret := _m.Called(ctx, ns)
+
+	var r0 []*fftypes.TokenConnector
+	if rf, ok := ret.Get(0).(func(context.Context, string) []*fftypes.TokenConnector); ok {
+		r0 = rf(ctx, ns)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*fftypes.TokenConnector)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, ns)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetTokenPool provides a mock function with given fields: ctx, ns, typeName, poolName
 func (_m *Manager) GetTokenPool(ctx context.Context, ns string, typeName string, poolName string) (*fftypes.TokenPool, error) {
 	ret := _m.Called(ctx, ns, typeName, poolName)

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -389,6 +389,11 @@ type iTokenTransferCollection interface {
 	GetTokenTransfers(ctx context.Context, filter Filter) ([]*fftypes.TokenTransfer, *FilterResult, error)
 }
 
+type iTokenConnectorsCollection interface {
+	// GetTokenConnectors - Get token connectors
+	GetTokenConnectors(ctx context.Context, filter Filter) ([]*fftypes.TokenConnector, error)
+}
+
 // PeristenceInterface are the operations that must be implemented by a database interfavce plugin.
 // The database mechanism of Firefly is designed to provide the balance between being able
 // to query the data a member of the network has transferred/received via Firefly efficiently,

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -389,11 +389,6 @@ type iTokenTransferCollection interface {
 	GetTokenTransfers(ctx context.Context, filter Filter) ([]*fftypes.TokenTransfer, *FilterResult, error)
 }
 
-type iTokenConnectorsCollection interface {
-	// GetTokenConnectors - Get token connectors
-	GetTokenConnectors(ctx context.Context, filter Filter) ([]*fftypes.TokenConnector, error)
-}
-
 // PeristenceInterface are the operations that must be implemented by a database interfavce plugin.
 // The database mechanism of Firefly is designed to provide the balance between being able
 // to query the data a member of the network has transferred/received via Firefly efficiently,

--- a/pkg/fftypes/tokenconnector.go
+++ b/pkg/fftypes/tokenconnector.go
@@ -1,0 +1,30 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fftypes
+
+import "context"
+
+type TokenConnector struct {
+	Name string `json:"name,omitempty"`
+}
+
+func (t *TokenConnector) Validate(ctx context.Context, existing bool) (err error) {
+	if err = ValidateFFNameField(ctx, t.Name, "name"); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/fftypes/tokenconnector_test.go
+++ b/pkg/fftypes/tokenconnector_test.go
@@ -25,15 +25,9 @@ import (
 
 func TestTokenConnectorValidation(t *testing.T) {
 	connector := &TokenConnector{
-		Name: "ok",
-	}
-	err := connector.Validate(context.Background(), false)
-	assert.Regexp(t, "FF10131.*'namespace'", err)
-
-	connector = &TokenConnector{
 		Name: "!wrong",
 	}
-	err = connector.Validate(context.Background(), false)
+	err := connector.Validate(context.Background(), false)
 	assert.Regexp(t, "FF10131.*'name'", err)
 
 	connector = &TokenConnector{

--- a/pkg/fftypes/tokenconnector_test.go
+++ b/pkg/fftypes/tokenconnector_test.go
@@ -1,0 +1,44 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fftypes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTokenConnectorValidation(t *testing.T) {
+	connector := &TokenConnector{
+		Name: "ok",
+	}
+	err := connector.Validate(context.Background(), false)
+	assert.Regexp(t, "FF10131.*'namespace'", err)
+
+	connector = &TokenConnector{
+		Name: "!wrong",
+	}
+	err = connector.Validate(context.Background(), false)
+	assert.Regexp(t, "FF10131.*'name'", err)
+
+	connector = &TokenConnector{
+		Name: "ok",
+	}
+	err = connector.Validate(context.Background(), false)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
To support the new [Tokens Page in the UI](https://github.com/hyperledger/firefly-ui/issues/65), an endpoint to get all connectors in the network is needed.

```GET /namespaces/<namespace>/tokens/connectors``` returns all token connectors in the network in the following format:
```json
[
  {
    "name": "connector1"
  },
  {
    "name": "connector2"
  }
]
```