### PR TITLE
Replace FFI param InternalType (string) with Details (bytes)

### DIFF
--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -6,7 +6,8 @@ components:
           items:
             $ref: '#/components/schemas/FFIParam'
           type: array
-        internalType:
+        details:
+          format: byte
           type: string
         name:
           type: string
@@ -361,7 +362,8 @@ paths:
                                 items:
                                   $ref: '#/components/schemas/FFIParam'
                                 type: array
-                              internalType:
+                              details:
+                                format: byte
                                 type: string
                               name:
                                 type: string
@@ -384,7 +386,8 @@ paths:
                                 items:
                                   $ref: '#/components/schemas/FFIParam'
                                 type: array
-                              internalType:
+                              details:
+                                format: byte
                                 type: string
                               name:
                                 type: string
@@ -399,7 +402,8 @@ paths:
                                 items:
                                   $ref: '#/components/schemas/FFIParam'
                                 type: array
-                              internalType:
+                              details:
+                                format: byte
                                 type: string
                               name:
                                 type: string
@@ -556,7 +560,8 @@ paths:
                             items:
                               $ref: '#/components/schemas/FFIParam'
                             type: array
-                          internalType:
+                          details:
+                            format: byte
                             type: string
                           name:
                             type: string
@@ -571,7 +576,8 @@ paths:
                             items:
                               $ref: '#/components/schemas/FFIParam'
                             type: array
-                          internalType:
+                          details:
+                            format: byte
                             type: string
                           name:
                             type: string
@@ -1308,7 +1314,8 @@ paths:
                                 items:
                                   $ref: '#/components/schemas/FFIParam'
                                 type: array
-                              internalType:
+                              details:
+                                format: byte
                                 type: string
                               name:
                                 type: string
@@ -1331,7 +1338,8 @@ paths:
                                 items:
                                   $ref: '#/components/schemas/FFIParam'
                                 type: array
-                              internalType:
+                              details:
+                                format: byte
                                 type: string
                               name:
                                 type: string
@@ -1346,7 +1354,8 @@ paths:
                                 items:
                                   $ref: '#/components/schemas/FFIParam'
                                 type: array
-                              internalType:
+                              details:
+                                format: byte
                                 type: string
                               name:
                                 type: string
@@ -1408,7 +1417,8 @@ paths:
                               items:
                                 $ref: '#/components/schemas/FFIParam'
                               type: array
-                            internalType:
+                            details:
+                              format: byte
                               type: string
                             name:
                               type: string
@@ -1429,7 +1439,8 @@ paths:
                               items:
                                 $ref: '#/components/schemas/FFIParam'
                               type: array
-                            internalType:
+                            details:
+                              format: byte
                               type: string
                             name:
                               type: string
@@ -1444,7 +1455,8 @@ paths:
                               items:
                                 $ref: '#/components/schemas/FFIParam'
                               type: array
-                            internalType:
+                            details:
+                              format: byte
                               type: string
                             name:
                               type: string
@@ -1478,7 +1490,8 @@ paths:
                                 items:
                                   $ref: '#/components/schemas/FFIParam'
                                 type: array
-                              internalType:
+                              details:
+                                format: byte
                                 type: string
                               name:
                                 type: string
@@ -1501,7 +1514,8 @@ paths:
                                 items:
                                   $ref: '#/components/schemas/FFIParam'
                                 type: array
-                              internalType:
+                              details:
+                                format: byte
                                 type: string
                               name:
                                 type: string
@@ -1516,7 +1530,8 @@ paths:
                                 items:
                                   $ref: '#/components/schemas/FFIParam'
                                 type: array
-                              internalType:
+                              details:
+                                format: byte
                                 type: string
                               name:
                                 type: string
@@ -1581,7 +1596,8 @@ paths:
                                 items:
                                   $ref: '#/components/schemas/FFIParam'
                                 type: array
-                              internalType:
+                              details:
+                                format: byte
                                 type: string
                               name:
                                 type: string
@@ -1604,7 +1620,8 @@ paths:
                                 items:
                                   $ref: '#/components/schemas/FFIParam'
                                 type: array
-                              internalType:
+                              details:
+                                format: byte
                                 type: string
                               name:
                                 type: string
@@ -1619,7 +1636,8 @@ paths:
                                 items:
                                   $ref: '#/components/schemas/FFIParam'
                                 type: array
-                              internalType:
+                              details:
+                                format: byte
                                 type: string
                               name:
                                 type: string
@@ -1691,7 +1709,8 @@ paths:
                                 items:
                                   $ref: '#/components/schemas/FFIParam'
                                 type: array
-                              internalType:
+                              details:
+                                format: byte
                                 type: string
                               name:
                                 type: string
@@ -1714,7 +1733,8 @@ paths:
                                 items:
                                   $ref: '#/components/schemas/FFIParam'
                                 type: array
-                              internalType:
+                              details:
+                                format: byte
                                 type: string
                               name:
                                 type: string
@@ -1729,7 +1749,8 @@ paths:
                                 items:
                                   $ref: '#/components/schemas/FFIParam'
                                 type: array
-                              internalType:
+                              details:
+                                format: byte
                                 type: string
                               name:
                                 type: string
@@ -1796,7 +1817,8 @@ paths:
                             items:
                               $ref: '#/components/schemas/FFIParam'
                             type: array
-                          internalType:
+                          details:
+                            format: byte
                             type: string
                           name:
                             type: string
@@ -1811,7 +1833,8 @@ paths:
                             items:
                               $ref: '#/components/schemas/FFIParam'
                             type: array
-                          internalType:
+                          details:
+                            format: byte
                             type: string
                           name:
                             type: string

--- a/internal/blockchain/ethereum/ethereum.go
+++ b/internal/blockchain/ethereum/ethereum.go
@@ -403,7 +403,7 @@ func (e *Ethereum) SubmitBatchPin(ctx context.Context, operationID *fftypes.UUID
 }
 
 func (e *Ethereum) InvokeContract(ctx context.Context, operationID *fftypes.UUID, signingKey string, location fftypes.Byteable, method *fftypes.FFIMethod, params map[string]interface{}) (interface{}, error) {
-	contractAddress, err := parseContractLocation(location)
+	contractAddress, err := parseContractLocation(ctx, location)
 	if err != nil {
 		return nil, err
 	}
@@ -421,28 +421,28 @@ func (e *Ethereum) InvokeContract(ctx context.Context, operationID *fftypes.UUID
 }
 
 func (e *Ethereum) ValidateContractLocation(ctx context.Context, location fftypes.Byteable) (err error) {
-	_, err = parseContractLocation(location)
+	_, err = parseContractLocation(ctx, location)
 	return
 }
 
-func parseContractLocation(location fftypes.Byteable) (*Location, error) {
+func parseContractLocation(ctx context.Context, location fftypes.Byteable) (*Location, error) {
 	ethLocation := &Location{}
 	if err := json.Unmarshal(location, &ethLocation); err != nil {
-		return nil, fmt.Errorf("failed to validate on chain location")
+		return nil, i18n.NewError(ctx, i18n.MsgContractLocationInvalid, err)
 	}
 	if ethLocation.Address == "" {
-		return nil, fmt.Errorf("failed to validate on chain location: 'channel' not set")
+		return nil, i18n.NewError(ctx, i18n.MsgContractLocationInvalid, "'address' not set")
 	}
 	return ethLocation, nil
 }
 
-func parseParamDetails(details fftypes.Byteable) (*paramDetails, error) {
+func parseParamDetails(ctx context.Context, details fftypes.Byteable) (*paramDetails, error) {
 	ethParam := &paramDetails{}
 	if err := json.Unmarshal(details, &ethParam); err != nil {
-		return nil, fmt.Errorf("failed to validate param")
+		return nil, i18n.NewError(ctx, i18n.MsgContractParamInvalid, err)
 	}
 	if ethParam.Type == "" {
-		return nil, fmt.Errorf("failed to validate param: 'type' not set")
+		return nil, i18n.NewError(ctx, i18n.MsgContractParamInvalid, "'type' not set")
 	}
 	return ethParam, nil
 }
@@ -450,7 +450,7 @@ func parseParamDetails(details fftypes.Byteable) (*paramDetails, error) {
 var intRegex, _ = regexp.Compile("^u?int([0-9]{1,3})$")
 
 func (e *Ethereum) ValidateFFIParam(ctx context.Context, param *fftypes.FFIParam) error {
-	paramDetails, err := parseParamDetails(param.Details)
+	paramDetails, err := parseParamDetails(ctx, param.Details)
 	if err != nil {
 		return err
 	}

--- a/internal/blockchain/ethereum/ethereum_test.go
+++ b/internal/blockchain/ethereum/ethereum_test.go
@@ -961,26 +961,31 @@ func TestFormatNil(t *testing.T) {
 	assert.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000000", ethHexFormatB32(nil))
 }
 
+func encodeDetails(internalType string) []byte {
+	result, _ := json.Marshal(&paramDetails{Type: internalType})
+	return result
+}
+
 func TestValidateFFIParamInteger(t *testing.T) {
 	e := &Ethereum{}
 	param := &fftypes.FFIParam{
-		Name:         "TestParam",
-		Type:         "integer",
-		InternalType: "uint32",
+		Name:    "TestParam",
+		Type:    "integer",
+		Details: encodeDetails("uint32"),
 	}
 	assert.NoError(t, e.ValidateFFIParam(context.Background(), param))
 
 	param = &fftypes.FFIParam{
-		Name:         "TestParam",
-		Type:         "integer",
-		InternalType: "int16",
+		Name:    "TestParam",
+		Type:    "integer",
+		Details: encodeDetails("int16"),
 	}
 	assert.NoError(t, e.ValidateFFIParam(context.Background(), param))
 
 	param = &fftypes.FFIParam{
-		Name:         "TestParam",
-		Type:         "integer",
-		InternalType: "uint256",
+		Name:    "TestParam",
+		Type:    "integer",
+		Details: encodeDetails("uint256"),
 	}
 	assert.NoError(t, e.ValidateFFIParam(context.Background(), param))
 }
@@ -988,23 +993,23 @@ func TestValidateFFIParamInteger(t *testing.T) {
 func TestValidateFFIParamIntegerInvalid(t *testing.T) {
 	e := &Ethereum{}
 	param := &fftypes.FFIParam{
-		Name:         "TestParam",
-		Type:         "integer",
-		InternalType: "string",
+		Name:    "TestParam",
+		Type:    "integer",
+		Details: encodeDetails("string"),
 	}
 	assert.Error(t, e.ValidateFFIParam(context.Background(), param))
 
 	param = &fftypes.FFIParam{
-		Name:         "TestParam",
-		Type:         "integer",
-		InternalType: "uintfoo",
+		Name:    "TestParam",
+		Type:    "integer",
+		Details: encodeDetails("uintfoo"),
 	}
 	assert.Error(t, e.ValidateFFIParam(context.Background(), param))
 
 	param = &fftypes.FFIParam{
-		Name:         "TestParam",
-		Type:         "integer",
-		InternalType: "int7",
+		Name:    "TestParam",
+		Type:    "integer",
+		Details: encodeDetails("int7"),
 	}
 	assert.Error(t, e.ValidateFFIParam(context.Background(), param))
 }
@@ -1012,22 +1017,22 @@ func TestValidateFFIParamIntegerInvalid(t *testing.T) {
 func TestValidateFFIParamByteArray(t *testing.T) {
 	e := &Ethereum{}
 	param := &fftypes.FFIParam{
-		Name:         "TestParam",
-		Type:         "byte[]",
-		InternalType: "byte[]",
+		Name:    "TestParam",
+		Type:    "byte[]",
+		Details: encodeDetails("byte[]"),
 	}
 	assert.NoError(t, e.ValidateFFIParam(context.Background(), param))
 
 	param = &fftypes.FFIParam{
-		Type:         "byte[]",
-		InternalType: "bytes",
+		Type:    "byte[]",
+		Details: encodeDetails("bytes"),
 	}
 	assert.NoError(t, e.ValidateFFIParam(context.Background(), param))
 
 	param = &fftypes.FFIParam{
-		Name:         "TestParam",
-		Type:         "byte[]",
-		InternalType: "bytes32",
+		Name:    "TestParam",
+		Type:    "byte[]",
+		Details: encodeDetails("bytes32"),
 	}
 	assert.NoError(t, e.ValidateFFIParam(context.Background(), param))
 }
@@ -1035,9 +1040,9 @@ func TestValidateFFIParamByteArray(t *testing.T) {
 func TestValidateFFIParamByteArrayInvalid(t *testing.T) {
 	e := &Ethereum{}
 	param := &fftypes.FFIParam{
-		Name:         "TestParam",
-		Type:         "byte[]",
-		InternalType: "bool",
+		Name:    "TestParam",
+		Type:    "byte[]",
+		Details: encodeDetails("bool"),
 	}
 	assert.Error(t, e.ValidateFFIParam(context.Background(), param))
 }
@@ -1045,16 +1050,16 @@ func TestValidateFFIParamByteArrayInvalid(t *testing.T) {
 func TestValidateFFIParamArray(t *testing.T) {
 	e := &Ethereum{}
 	param := &fftypes.FFIParam{
-		Name:         "TestParam",
-		Type:         "string[]",
-		InternalType: "string[]",
+		Name:    "TestParam",
+		Type:    "string[]",
+		Details: encodeDetails("string[]"),
 	}
 	assert.NoError(t, e.ValidateFFIParam(context.Background(), param))
 
 	param = &fftypes.FFIParam{
-		Name:         "TestParam",
-		Type:         "integer[]",
-		InternalType: "uint256[]",
+		Name:    "TestParam",
+		Type:    "integer[]",
+		Details: encodeDetails("uint256[]"),
 	}
 	assert.NoError(t, e.ValidateFFIParam(context.Background(), param))
 }
@@ -1062,16 +1067,16 @@ func TestValidateFFIParamArray(t *testing.T) {
 func TestValidateFFIParamArrayInvalid(t *testing.T) {
 	e := &Ethereum{}
 	param := &fftypes.FFIParam{
-		Name:         "TestParam",
-		Type:         "string[][]",
-		InternalType: "string[]",
+		Name:    "TestParam",
+		Type:    "string[][]",
+		Details: encodeDetails("string[]"),
 	}
 	assert.Error(t, e.ValidateFFIParam(context.Background(), param))
 
 	param = &fftypes.FFIParam{
-		Name:         "TestParam",
-		Type:         "string[]",
-		InternalType: "uint32[]",
+		Name:    "TestParam",
+		Type:    "string[]",
+		Details: encodeDetails("uint32[]"),
 	}
 	assert.Error(t, e.ValidateFFIParam(context.Background(), param))
 }
@@ -1079,9 +1084,9 @@ func TestValidateFFIParamArrayInvalid(t *testing.T) {
 func TestValidateFFIParamBoolean(t *testing.T) {
 	e := &Ethereum{}
 	param := &fftypes.FFIParam{
-		Name:         "TestParam",
-		Type:         "boolean",
-		InternalType: "bool",
+		Name:    "TestParam",
+		Type:    "boolean",
+		Details: encodeDetails("bool"),
 	}
 	assert.NoError(t, e.ValidateFFIParam(context.Background(), param))
 }
@@ -1089,9 +1094,9 @@ func TestValidateFFIParamBoolean(t *testing.T) {
 func TestValidateFFIParamBooleanInvalid(t *testing.T) {
 	e := &Ethereum{}
 	param := &fftypes.FFIParam{
-		Name:         "TestParam",
-		Type:         "boolean",
-		InternalType: "boolean",
+		Name:    "TestParam",
+		Type:    "boolean",
+		Details: encodeDetails("boolean"),
 	}
 	assert.Error(t, e.ValidateFFIParam(context.Background(), param))
 }
@@ -1099,24 +1104,24 @@ func TestValidateFFIParamBooleanInvalid(t *testing.T) {
 func TestValidateFFIParamStruct(t *testing.T) {
 	e := &Ethereum{}
 	param := &fftypes.FFIParam{
-		Name:         "myWidget",
-		Type:         "Widget",
-		InternalType: "struct Widget",
+		Name:    "myWidget",
+		Type:    "Widget",
+		Details: encodeDetails("struct Widget"),
 		Components: []*fftypes.FFIParam{
 			{
-				Name:         "Size",
-				Type:         "integer",
-				InternalType: "uint8",
+				Name:    "Size",
+				Type:    "integer",
+				Details: encodeDetails("uint8"),
 			},
 			{
-				Name:         "Teeth",
-				Type:         "integer",
-				InternalType: "uint16",
+				Name:    "Teeth",
+				Type:    "integer",
+				Details: encodeDetails("uint16"),
 			},
 			{
-				Name:         "Ddescription",
-				Type:         "string",
-				InternalType: "string",
+				Name:    "Ddescription",
+				Type:    "string",
+				Details: encodeDetails("string"),
 			},
 		},
 	}
@@ -1126,24 +1131,24 @@ func TestValidateFFIParamStruct(t *testing.T) {
 func TestValidateFFIParamStructInvalid(t *testing.T) {
 	e := &Ethereum{}
 	param := &fftypes.FFIParam{
-		Name:         "myWidget",
-		Type:         "Widget",
-		InternalType: "struct Widget",
+		Name:    "myWidget",
+		Type:    "Widget",
+		Details: encodeDetails("struct Widget"),
 		Components: []*fftypes.FFIParam{
 			{
-				Name:         "Size",
-				Type:         "integer",
-				InternalType: "uint8",
+				Name:    "Size",
+				Type:    "integer",
+				Details: encodeDetails("uint8"),
 			},
 			{
-				Name:         "Teeth",
-				Type:         "integer",
-				InternalType: "string",
+				Name:    "Teeth",
+				Type:    "integer",
+				Details: encodeDetails("string"),
 			},
 			{
-				Name:         "Description",
-				Type:         "string",
-				InternalType: "string",
+				Name:    "Description",
+				Type:    "string",
+				Details: encodeDetails("string"),
 			},
 		},
 	}

--- a/internal/blockchain/fabric/fabric.go
+++ b/internal/blockchain/fabric/fabric.go
@@ -520,7 +520,7 @@ func (f *Fabric) InvokeContract(ctx context.Context, operationID *fftypes.UUID, 
 		}
 	}
 
-	fabricOnChainLocation, err := parseContractLocation(location)
+	fabricOnChainLocation, err := parseContractLocation(ctx, location)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse onChainLocation")
 	}
@@ -550,20 +550,20 @@ func jsonEncodeParams(params map[string]interface{}) (output map[string]string, 
 }
 
 func (f *Fabric) ValidateContractLocation(ctx context.Context, location fftypes.Byteable) (err error) {
-	_, err = parseContractLocation(location)
+	_, err = parseContractLocation(ctx, location)
 	return
 }
 
-func parseContractLocation(location fftypes.Byteable) (*Location, error) {
+func parseContractLocation(ctx context.Context, location fftypes.Byteable) (*Location, error) {
 	fabricLocation := &Location{}
 	if err := json.Unmarshal(location, &fabricLocation); err != nil {
-		return nil, fmt.Errorf("failed to validate on chain location")
+		return nil, i18n.NewError(ctx, i18n.MsgContractLocationInvalid, err)
 	}
 	if fabricLocation.Channel == "" {
-		return nil, fmt.Errorf("failed to validate on chain location: 'channel' not set")
+		return nil, i18n.NewError(ctx, i18n.MsgContractLocationInvalid, "'channel' not set")
 	}
 	if fabricLocation.Chaincode == "" {
-		return nil, fmt.Errorf("failed to validate on chain location: 'chaincode' not set")
+		return nil, i18n.NewError(ctx, i18n.MsgContractLocationInvalid, "'chaincode' not set")
 	}
 	return fabricLocation, nil
 }

--- a/internal/contracts/manager_test.go
+++ b/internal/contracts/manager_test.go
@@ -45,21 +45,21 @@ func TestValidateInvokeContractRequest(t *testing.T) {
 			Name: "sum",
 			Params: []*fftypes.FFIParam{
 				{
-					Name:         "x",
-					Type:         "integer",
-					InternalType: "uint256",
+					Name:    "x",
+					Type:    "integer",
+					Details: []byte("\"type\":\"uint256\"}"),
 				},
 				{
-					Name:         "y",
-					Type:         "integer",
-					InternalType: "uint256",
+					Name:    "y",
+					Type:    "integer",
+					Details: []byte("\"type\":\"uint256\"}"),
 				},
 			},
 			Returns: []*fftypes.FFIParam{
 				{
-					Name:         "z",
-					Type:         "integer",
-					InternalType: "uint256",
+					Name:    "z",
+					Type:    "integer",
+					Details: []byte("\"type\":\"uint256\"}"),
 				},
 			},
 		},
@@ -87,21 +87,21 @@ func TestValidateInvokeContractRequestMissingInput(t *testing.T) {
 			Name: "sum",
 			Params: []*fftypes.FFIParam{
 				{
-					Name:         "x",
-					Type:         "integer",
-					InternalType: "uint256",
+					Name:    "x",
+					Type:    "integer",
+					Details: []byte("\"type\":\"uint256\"}"),
 				},
 				{
-					Name:         "y",
-					Type:         "integer",
-					InternalType: "uint256",
+					Name:    "y",
+					Type:    "integer",
+					Details: []byte("\"type\":\"uint256\"}"),
 				},
 			},
 			Returns: []*fftypes.FFIParam{
 				{
-					Name:         "z",
-					Type:         "integer",
-					InternalType: "uint256",
+					Name:    "z",
+					Type:    "integer",
+					Details: []byte("\"type\":\"uint256\"}"),
 				},
 			},
 		},
@@ -128,21 +128,21 @@ func TestValidateInvokeContractRequestInputWrongType(t *testing.T) {
 			Name: "sum",
 			Params: []*fftypes.FFIParam{
 				{
-					Name:         "x",
-					Type:         "integer",
-					InternalType: "uint256",
+					Name:    "x",
+					Type:    "integer",
+					Details: []byte("\"type\":\"uint256\"}"),
 				},
 				{
-					Name:         "y",
-					Type:         "integer",
-					InternalType: "uint256",
+					Name:    "y",
+					Type:    "integer",
+					Details: []byte("\"type\":\"uint256\"}"),
 				},
 			},
 			Returns: []*fftypes.FFIParam{
 				{
-					Name:         "z",
-					Type:         "integer",
-					InternalType: "uint256",
+					Name:    "z",
+					Type:    "integer",
+					Details: []byte("\"type\":\"uint256\"}"),
 				},
 			},
 		},
@@ -169,21 +169,21 @@ func TestValidateInvokeContractRequestInvalidParam(t *testing.T) {
 			Name: "sum",
 			Params: []*fftypes.FFIParam{
 				{
-					Name:         "x",
-					Type:         "integer",
-					InternalType: "uint256",
+					Name:    "x",
+					Type:    "integer",
+					Details: []byte("\"type\":\"uint256\"}"),
 				},
 				{
-					Name:         "y",
-					Type:         "integer",
-					InternalType: "uint256",
+					Name:    "y",
+					Type:    "integer",
+					Details: []byte("\"type\":\"uint256\"}"),
 				},
 			},
 			Returns: []*fftypes.FFIParam{
 				{
-					Name:         "z",
-					Type:         "integer",
-					InternalType: "uint256",
+					Name:    "z",
+					Type:    "integer",
+					Details: []byte("\"type\":\"uint256\"}"),
 				},
 			},
 		},
@@ -216,21 +216,21 @@ func TestValidateInvokeContractRequestInvalidMethod(t *testing.T) {
 		Name: "sum",
 		Params: []*fftypes.FFIParam{
 			{
-				Name:         "x",
-				Type:         "integer",
-				InternalType: "uint256",
+				Name:    "x",
+				Type:    "integer",
+				Details: []byte("\"type\":\"uint256\"}"),
 			},
 			{
-				Name:         "y",
-				Type:         "integer",
-				InternalType: "uint256",
+				Name:    "y",
+				Type:    "integer",
+				Details: []byte("\"type\":\"uint256\"}"),
 			},
 		},
 		Returns: []*fftypes.FFIParam{
 			{
-				Name:         "z",
-				Type:         "integer",
-				InternalType: "uint256",
+				Name:    "z",
+				Type:    "integer",
+				Details: []byte("\"type\":\"uint256\"}"),
 			},
 		},
 	}
@@ -258,14 +258,14 @@ func TestValidateInvokeContractRequestInvalidEvent(t *testing.T) {
 		Name: "sum",
 		Params: []*fftypes.FFIParam{
 			{
-				Name:         "x",
-				Type:         "integer",
-				InternalType: "uint256",
+				Name:    "x",
+				Type:    "integer",
+				Details: []byte("\"type\":\"uint256\"}"),
 			},
 			{
-				Name:         "y",
-				Type:         "integer",
-				InternalType: "uint256",
+				Name:    "y",
+				Type:    "integer",
+				Details: []byte("\"type\":\"uint256\"}"),
 			},
 		},
 	}
@@ -291,21 +291,21 @@ func TestValidateFFI(t *testing.T) {
 				Name: "sum",
 				Params: []*fftypes.FFIParam{
 					{
-						Name:         "x",
-						Type:         "integer",
-						InternalType: "uint256",
+						Name:    "x",
+						Type:    "integer",
+						Details: []byte("\"type\":\"uint256\"}"),
 					},
 					{
-						Name:         "y",
-						Type:         "integer",
-						InternalType: "uint256",
+						Name:    "y",
+						Type:    "integer",
+						Details: []byte("\"type\":\"uint256\"}"),
 					},
 				},
 				Returns: []*fftypes.FFIParam{
 					{
-						Name:         "z",
-						Type:         "integer",
-						InternalType: "uint256",
+						Name:    "z",
+						Type:    "integer",
+						Details: []byte("\"type\":\"uint256\"}"),
 					},
 				},
 			},
@@ -315,9 +315,9 @@ func TestValidateFFI(t *testing.T) {
 				Name: "sum",
 				Params: []*fftypes.FFIParam{
 					{
-						Name:         "z",
-						Type:         "integer",
-						InternalType: "uint256",
+						Name:    "z",
+						Type:    "integer",
+						Details: []byte("\"type\":\"uint256\"}"),
 					},
 				},
 			},
@@ -345,21 +345,21 @@ func TestValidateFFIBadMethodParam(t *testing.T) {
 				Name: "sum",
 				Params: []*fftypes.FFIParam{
 					{
-						Name:         "x",
-						Type:         "integer",
-						InternalType: "uint256",
+						Name:    "x",
+						Type:    "integer",
+						Details: []byte("\"type\":\"uint256\"}"),
 					},
 					{
-						Name:         "y",
-						Type:         "integer",
-						InternalType: "uint256",
+						Name:    "y",
+						Type:    "integer",
+						Details: []byte("\"type\":\"uint256\"}"),
 					},
 				},
 				Returns: []*fftypes.FFIParam{
 					{
-						Name:         "z",
-						Type:         "integer",
-						InternalType: "uint256",
+						Name:    "z",
+						Type:    "integer",
+						Details: []byte("\"type\":\"uint256\"}"),
 					},
 				},
 			},
@@ -369,9 +369,9 @@ func TestValidateFFIBadMethodParam(t *testing.T) {
 				Name: "sum",
 				Params: []*fftypes.FFIParam{
 					{
-						Name:         "z",
-						Type:         "integer",
-						InternalType: "uint256",
+						Name:    "z",
+						Type:    "integer",
+						Details: []byte("\"type\":\"uint256\"}"),
 					},
 				},
 			},
@@ -400,21 +400,21 @@ func TestValidateFFIBadMethodReturnParam(t *testing.T) {
 				Name: "sum",
 				Params: []*fftypes.FFIParam{
 					{
-						Name:         "x",
-						Type:         "integer",
-						InternalType: "uint256",
+						Name:    "x",
+						Type:    "integer",
+						Details: []byte("\"type\":\"uint256\"}"),
 					},
 					{
-						Name:         "y",
-						Type:         "integer",
-						InternalType: "uint256",
+						Name:    "y",
+						Type:    "integer",
+						Details: []byte("\"type\":\"uint256\"}"),
 					},
 				},
 				Returns: []*fftypes.FFIParam{
 					{
-						Name:         "z",
-						Type:         "integer",
-						InternalType: "uint256",
+						Name:    "z",
+						Type:    "integer",
+						Details: []byte("\"type\":\"uint256\"}"),
 					},
 				},
 			},
@@ -424,9 +424,9 @@ func TestValidateFFIBadMethodReturnParam(t *testing.T) {
 				Name: "sum",
 				Params: []*fftypes.FFIParam{
 					{
-						Name:         "z",
-						Type:         "integer",
-						InternalType: "uint256",
+						Name:    "z",
+						Type:    "integer",
+						Details: []byte("\"type\":\"uint256\"}"),
 					},
 				},
 			},
@@ -455,21 +455,21 @@ func TestValidateFFIBadEventParam(t *testing.T) {
 				Name: "sum",
 				Params: []*fftypes.FFIParam{
 					{
-						Name:         "x",
-						Type:         "integer",
-						InternalType: "uint256",
+						Name:    "x",
+						Type:    "integer",
+						Details: []byte("\"type\":\"uint256\"}"),
 					},
 					{
-						Name:         "y",
-						Type:         "integer",
-						InternalType: "uint256",
+						Name:    "y",
+						Type:    "integer",
+						Details: []byte("\"type\":\"uint256\"}"),
 					},
 				},
 				Returns: []*fftypes.FFIParam{
 					{
-						Name:         "z",
-						Type:         "integer",
-						InternalType: "uint256",
+						Name:    "z",
+						Type:    "integer",
+						Details: []byte("\"type\":\"uint256\"}"),
 					},
 				},
 			},
@@ -479,9 +479,9 @@ func TestValidateFFIBadEventParam(t *testing.T) {
 				Name: "sum",
 				Params: []*fftypes.FFIParam{
 					{
-						Name:         "z",
-						Type:         "integer",
-						InternalType: "uint256",
+						Name:    "z",
+						Type:    "integer",
+						Details: []byte("\"type\":\"uint256\"}"),
 					},
 				},
 			},

--- a/internal/contracts/validator.go
+++ b/internal/contracts/validator.go
@@ -89,10 +89,10 @@ func checkParam(ctx context.Context, input interface{}, param *fftypes.FFIParam)
 func checkArrayType(ctx context.Context, input interface{}, param *fftypes.FFIParam) error {
 	elementType := strings.TrimSuffix(param.Type, "[]")
 	elementParam := &fftypes.FFIParam{
-		Name:         param.Name,
-		Type:         elementType,
-		InternalType: param.InternalType,
-		Components:   param.Components,
+		Name:       param.Name,
+		Type:       elementType,
+		Details:    param.Details,
+		Components: param.Components,
 	}
 	inputArray, ok := input.([]interface{})
 

--- a/internal/contracts/validator_test.go
+++ b/internal/contracts/validator_test.go
@@ -73,19 +73,19 @@ func TestNotAnArrayTypeCheck(t *testing.T) {
 
 func TestCustomTypeSimple(t *testing.T) {
 	param := &fftypes.FFIParam{
-		Name:         "testParam",
-		Type:         "struct CustomType",
-		InternalType: "struct",
+		Name:    "testParam",
+		Type:    "struct CustomType",
+		Details: []byte("{\"type\":\"struct\"}"),
 		Components: []*fftypes.FFIParam{
 			{
-				Name:         "foo",
-				Type:         "string",
-				InternalType: "string",
+				Name:    "foo",
+				Type:    "string",
+				Details: []byte("{\"type\":\"string\"}"),
 			},
 			{
-				Name:         "count",
-				Type:         "integer",
-				InternalType: "uint256",
+				Name:    "count",
+				Type:    "integer",
+				Details: []byte("{\"type\":\"uint256\"}"),
 			},
 		},
 	}
@@ -99,19 +99,19 @@ func TestCustomTypeSimple(t *testing.T) {
 
 func TestCustomTypeWrongType(t *testing.T) {
 	param := &fftypes.FFIParam{
-		Name:         "testParam",
-		Type:         "struct CustomType",
-		InternalType: "struct",
+		Name:    "testParam",
+		Type:    "struct CustomType",
+		Details: []byte("\"type\":\"struct\"}"),
 		Components: []*fftypes.FFIParam{
 			{
-				Name:         "foo",
-				Type:         "string",
-				InternalType: "string",
+				Name:    "foo",
+				Type:    "string",
+				Details: []byte("\"type\":\"string\"}"),
 			},
 			{
-				Name:         "count",
-				Type:         "integer",
-				InternalType: "uint256",
+				Name:    "count",
+				Type:    "integer",
+				Details: []byte("\"type\":\"uint256\"}"),
 			},
 		},
 	}
@@ -125,19 +125,19 @@ func TestCustomTypeWrongType(t *testing.T) {
 
 func TestCustomTypeFieldMissing(t *testing.T) {
 	param := &fftypes.FFIParam{
-		Name:         "testParam",
-		Type:         "struct CustomType",
-		InternalType: "struct",
+		Name:    "testParam",
+		Type:    "struct CustomType",
+		Details: []byte("\"type\":\"struct\"}"),
 		Components: []*fftypes.FFIParam{
 			{
-				Name:         "foo",
-				Type:         "string",
-				InternalType: "string",
+				Name:    "foo",
+				Type:    "string",
+				Details: []byte("\"type\":\"string\"}"),
 			},
 			{
-				Name:         "count",
-				Type:         "integer",
-				InternalType: "uint256",
+				Name:    "count",
+				Type:    "integer",
+				Details: []byte("\"type\":\"uint256\"}"),
 			},
 		},
 	}
@@ -151,19 +151,19 @@ func TestCustomTypeFieldMissing(t *testing.T) {
 
 func TestCustomTypeInvalid(t *testing.T) {
 	param := &fftypes.FFIParam{
-		Name:         "testParam",
-		Type:         "struct CustomType",
-		InternalType: "struct",
+		Name:    "testParam",
+		Type:    "struct CustomType",
+		Details: []byte("\"type\":\"struct\"}"),
 		Components: []*fftypes.FFIParam{
 			{
-				Name:         "foo",
-				Type:         "string",
-				InternalType: "string",
+				Name:    "foo",
+				Type:    "string",
+				Details: []byte("\"type\":\"string\"}"),
 			},
 			{
-				Name:         "count",
-				Type:         "integer",
-				InternalType: "uint256",
+				Name:    "count",
+				Type:    "integer",
+				Details: []byte("\"type\":\"uint256\"}"),
 			},
 		},
 	}
@@ -177,19 +177,19 @@ func TestCustomTypeInvalid(t *testing.T) {
 
 func TestArrayOfCustomType(t *testing.T) {
 	param := &fftypes.FFIParam{
-		Name:         "testParam",
-		Type:         "struct CustomType[]",
-		InternalType: "struct[]",
+		Name:    "testParam",
+		Type:    "struct CustomType[]",
+		Details: []byte("\"type\":\"struct[]\"}"),
 		Components: []*fftypes.FFIParam{
 			{
-				Name:         "foo",
-				Type:         "string",
-				InternalType: "string",
+				Name:    "foo",
+				Type:    "string",
+				Details: []byte("\"type\":\"string\"}"),
 			},
 			{
-				Name:         "count",
-				Type:         "integer",
-				InternalType: "uint256",
+				Name:    "count",
+				Type:    "integer",
+				Details: []byte("\"type\":\"uint256\"}"),
 			},
 		},
 	}
@@ -213,14 +213,14 @@ func TestArrayOfCustomType(t *testing.T) {
 
 func TestNullValue(t *testing.T) {
 	param := &fftypes.FFIParam{
-		Name:         "testParam",
-		Type:         "struct CustomType",
-		InternalType: "struct",
+		Name:    "testParam",
+		Type:    "struct CustomType",
+		Details: []byte("\"type\":\"struct\"}"),
 		Components: []*fftypes.FFIParam{
 			{
-				Name:         "foo",
-				Type:         "string",
-				InternalType: "string",
+				Name:    "foo",
+				Type:    "string",
+				Details: []byte("\"type\":\"string\"}"),
 			},
 		},
 	}
@@ -234,9 +234,9 @@ func TestNullValue(t *testing.T) {
 
 func TestInvalidTypeMapping(t *testing.T) {
 	param := &fftypes.FFIParam{
-		Name:         "foo",
-		Type:         "integer",
-		InternalType: "uint256",
+		Name:    "foo",
+		Type:    "integer",
+		Details: []byte("\"type\":\"uint256\"}"),
 	}
 	var i float32 = 32
 	err := checkParam(context.Background(), i, param)
@@ -245,29 +245,29 @@ func TestInvalidTypeMapping(t *testing.T) {
 
 func TestComplexCustomType(t *testing.T) {
 	param := &fftypes.FFIParam{
-		Name:         "testParam",
-		Type:         "struct CustomType[][]",
-		InternalType: "struct",
+		Name:    "testParam",
+		Type:    "struct CustomType[][]",
+		Details: []byte("\"type\":\"struct\"}"),
 		Components: []*fftypes.FFIParam{
 			{
-				Name:         "x",
-				Type:         "integer",
-				InternalType: "uint256",
+				Name:    "x",
+				Type:    "integer",
+				Details: []byte("\"type\":\"uint256\"}"),
 			},
 			{
-				Name:         "y",
-				Type:         "integer",
-				InternalType: "uint256",
+				Name:    "y",
+				Type:    "integer",
+				Details: []byte("\"type\":\"uint256\"}"),
 			},
 			{
-				Name:         "foo",
-				Type:         "struct Foo",
-				InternalType: "struct",
+				Name:    "foo",
+				Type:    "struct Foo",
+				Details: []byte("\"type\":\"struct\"}"),
 				Components: []*fftypes.FFIParam{
 					{
-						Name:         "bar",
-						Type:         "string",
-						InternalType: "string",
+						Name:    "bar",
+						Type:    "string",
+						Details: []byte("\"type\":\"string\"}"),
 					},
 				},
 			},
@@ -286,29 +286,29 @@ func TestComplexCustomType(t *testing.T) {
 
 func TestBadComplexCustomType(t *testing.T) {
 	param := &fftypes.FFIParam{
-		Name:         "testParam",
-		Type:         "struct CustomType[][]",
-		InternalType: "struct",
+		Name:    "testParam",
+		Type:    "struct CustomType[][]",
+		Details: []byte("\"type\":\"struct\"}"),
 		Components: []*fftypes.FFIParam{
 			{
-				Name:         "x",
-				Type:         "integer",
-				InternalType: "uint256",
+				Name:    "x",
+				Type:    "integer",
+				Details: []byte("\"type\":\"uint256\"}"),
 			},
 			{
-				Name:         "y",
-				Type:         "integer",
-				InternalType: "uint256",
+				Name:    "y",
+				Type:    "integer",
+				Details: []byte("\"type\":\"uint256\"}"),
 			},
 			{
-				Name:         "foo",
-				Type:         "struct Foo",
-				InternalType: "struct",
+				Name:    "foo",
+				Type:    "struct Foo",
+				Details: []byte("\"type\":\"struct\"}"),
 				Components: []*fftypes.FFIParam{
 					{
-						Name:         "bar",
-						Type:         "string",
-						InternalType: "string",
+						Name:    "bar",
+						Type:    "string",
+						Details: []byte("\"type\":\"string\"}"),
 					},
 				},
 			},

--- a/internal/database/sqlcommon/ffi_events_sql_test.go
+++ b/internal/database/sqlcommon/ffi_events_sql_test.go
@@ -40,9 +40,9 @@ func TestFFIEventsE2EWithDB(t *testing.T) {
 		Name: "Changed",
 		Params: fftypes.FFIParams{
 			{
-				Name:         "value",
-				Type:         "integer",
-				InternalType: "uint256",
+				Name:    "value",
+				Type:    "integer",
+				Details: []byte("\"internal-type-info\""),
 			},
 		},
 	}

--- a/internal/database/sqlcommon/ffi_methods_sql_test.go
+++ b/internal/database/sqlcommon/ffi_methods_sql_test.go
@@ -40,16 +40,16 @@ func TestFFIMethodsE2EWithDB(t *testing.T) {
 		Name: "Set",
 		Params: fftypes.FFIParams{
 			{
-				Name:         "value",
-				Type:         "integer",
-				InternalType: "uint256",
+				Name:    "value",
+				Type:    "integer",
+				Details: []byte("\"internal-type-info\""),
 			},
 		},
 		Returns: fftypes.FFIParams{
 			{
-				Name:         "value",
-				Type:         "integer",
-				InternalType: "uint256",
+				Name:    "value",
+				Type:    "integer",
+				Details: []byte("\"internal-type-info\""),
 			},
 		},
 	}

--- a/internal/i18n/en_translations.go
+++ b/internal/i18n/en_translations.go
@@ -219,4 +219,6 @@ var (
 	MsgContractMapInputType         = ffm("FF10299", "Unable to map input type '%v' to known FireFly type - was expecting '%v'", 400)
 	MsgContractByteDecode           = ffm("FF10300", "Unable to decode field '%v' as bytes", 400)
 	MsgContractInternalType         = ffm("FF10301", "Input '%v' of type '%v' is not compatible blockchain internalType of '%v'", 400)
+	MsgContractLocationInvalid      = ffm("FF10302", "Failed to validate contract location: %v", 400)
+	MsgContractParamInvalid         = ffm("FF10303", "Failed to validate contract param: %v", 400)
 )

--- a/pkg/fftypes/ffi.go
+++ b/pkg/fftypes/ffi.go
@@ -48,10 +48,10 @@ type FFIEvent struct {
 }
 
 type FFIParam struct {
-	Name         string      `json:"name"`
-	InternalType string      `json:"internalType"`
-	Type         string      `json:"type"`
-	Components   []*FFIParam `json:"components,omitempty"`
+	Name       string      `json:"name"`
+	Type       string      `json:"type"`
+	Details    Byteable    `json:"details"`
+	Components []*FFIParam `json:"components,omitempty"`
 }
 
 type FFIParams []*FFIParam


### PR DESCRIPTION
Each blockchain plugin may have different representations of valid types,
and a single string field may not be sufficient. This allows the blockchain
plugin to pack/unpack an arbitrary amount of type info.

Signed-off-by: Andrew Richardson <andrew.richardson@kaleido.io>