### PR TITLE
Create an event on new TX submission, and streamline TX DB ops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ $(eval $(call makemock, pkg/dataexchange,          Callbacks,          dataexcha
 $(eval $(call makemock, pkg/tokens,                Plugin,             tokenmocks))
 $(eval $(call makemock, pkg/tokens,                Callbacks,          tokenmocks))
 $(eval $(call makemock, pkg/wsclient,              WSClient,           wsmocks))
+$(eval $(call makemock, internal/txcommon,         Helper,             txcommonmocks))
 $(eval $(call makemock, internal/identity,         Manager,            identitymanagermocks))
 $(eval $(call makemock, internal/batchpin,         Submitter,          batchpinmocks))
 $(eval $(call makemock, internal/sysmessaging,     SystemEvents,       sysmessagingmocks))

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -4231,6 +4231,7 @@ paths:
                     type: integer
                   type:
                     enum:
+                    - transaction_submitted
                     - message_confirmed
                     - message_rejected
                     - namespace_confirmed
@@ -4291,6 +4292,7 @@ paths:
                     type: integer
                   type:
                     enum:
+                    - transaction_submitted
                     - message_confirmed
                     - message_rejected
                     - namespace_confirmed
@@ -4962,6 +4964,7 @@ paths:
                     type: integer
                   type:
                     enum:
+                    - transaction_submitted
                     - message_confirmed
                     - message_rejected
                     - namespace_confirmed

--- a/internal/assets/manager.go
+++ b/internal/assets/manager.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hyperledger/firefly/internal/retry"
 	"github.com/hyperledger/firefly/internal/syncasync"
 	"github.com/hyperledger/firefly/internal/sysmessaging"
+	"github.com/hyperledger/firefly/internal/txcommon"
 	"github.com/hyperledger/firefly/pkg/database"
 	"github.com/hyperledger/firefly/pkg/fftypes"
 	"github.com/hyperledger/firefly/pkg/tokens"
@@ -70,6 +71,7 @@ type Manager interface {
 type assetManager struct {
 	ctx       context.Context
 	database  database.Plugin
+	txHelper  txcommon.Helper
 	identity  identity.Manager
 	data      data.Manager
 	syncasync syncasync.Bridge
@@ -86,6 +88,7 @@ func NewAssetManager(ctx context.Context, di database.Plugin, im identity.Manage
 	am := &assetManager{
 		ctx:       ctx,
 		database:  di,
+		txHelper:  txcommon.NewTransactionHelper(di),
 		identity:  im,
 		data:      dm,
 		syncasync: sa,

--- a/internal/assets/manager_test.go
+++ b/internal/assets/manager_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hyperledger/firefly/mocks/privatemessagingmocks"
 	"github.com/hyperledger/firefly/mocks/syncasyncmocks"
 	"github.com/hyperledger/firefly/mocks/tokenmocks"
+	"github.com/hyperledger/firefly/mocks/txcommonmocks"
 	"github.com/hyperledger/firefly/pkg/database"
 	"github.com/hyperledger/firefly/pkg/fftypes"
 	"github.com/hyperledger/firefly/pkg/tokens"
@@ -51,7 +52,9 @@ func newTestAssets(t *testing.T) (*assetManager, func()) {
 		rag.ReturnArguments = mock.Arguments{a[1].(func(context.Context) error)(a[0].(context.Context))}
 	}
 	assert.NoError(t, err)
-	return a.(*assetManager), cancel
+	am := a.(*assetManager)
+	am.txHelper = &txcommonmocks.Helper{}
+	return am, cancel
 }
 
 func TestInitFail(t *testing.T) {

--- a/internal/assets/token_pool.go
+++ b/internal/assets/token_pool.go
@@ -84,30 +84,26 @@ func (am *assetManager) createTokenPoolInternal(ctx context.Context, pool *fftyp
 		})
 	}
 
-	tx := &fftypes.Transaction{
-		ID:        fftypes.NewUUID(),
-		Namespace: pool.Namespace,
-		Type:      fftypes.TransactionTypeTokenPool,
-		Created:   fftypes.Now(),
-	}
-	pool.TX.ID = tx.ID
-	pool.TX.Type = tx.Type
-
-	op := fftypes.NewTXOperation(
-		plugin,
-		pool.Namespace,
-		tx.ID,
-		"",
-		fftypes.OpTypeTokenCreatePool,
-		fftypes.OpStatusPending)
-	txcommon.AddTokenPoolCreateInputs(op, pool)
-
+	var op *fftypes.Operation
 	err = am.database.RunAsGroup(ctx, func(ctx context.Context) (err error) {
-		err = am.database.UpsertTransaction(ctx, tx)
-		if err == nil {
-			err = am.database.InsertOperation(ctx, op)
+		txid, err := am.txHelper.SubmitNewTransaction(ctx, pool.Namespace, fftypes.TransactionTypeTokenPool)
+		if err != nil {
+			return err
 		}
-		return err
+
+		pool.TX.ID = txid
+		pool.TX.Type = fftypes.TransactionTypeTokenPool
+
+		op = fftypes.NewTXOperation(
+			plugin,
+			pool.Namespace,
+			txid,
+			"",
+			fftypes.OpTypeTokenCreatePool,
+			fftypes.OpStatusPending)
+		txcommon.AddTokenPoolCreateInputs(op, pool)
+
+		return am.database.InsertOperation(ctx, op)
 	})
 	if err != nil {
 		return nil, err

--- a/internal/assets/token_transfer.go
+++ b/internal/assets/token_transfer.go
@@ -246,25 +246,8 @@ func (s *transferSender) sendInternal(ctx context.Context, method sendMethod) er
 		return nil
 	}
 
-	tx := &fftypes.Transaction{
-		ID:        fftypes.NewUUID(),
-		Namespace: s.namespace,
-		Type:      fftypes.TransactionTypeTokenTransfer,
-		Created:   fftypes.Now(),
-	}
-	s.transfer.TX.ID = tx.ID
-	s.transfer.TX.Type = tx.Type
-
-	op := fftypes.NewTXOperation(
-		plugin,
-		s.namespace,
-		tx.ID,
-		"",
-		fftypes.OpTypeTokenTransfer,
-		fftypes.OpStatusPending)
-	txcommon.AddTokenTransferInputs(op, &s.transfer.TokenTransfer)
-
 	var pool *fftypes.TokenPool
+	var op *fftypes.Operation
 	err = s.mgr.database.RunAsGroup(ctx, func(ctx context.Context) (err error) {
 		pool, err = s.mgr.GetTokenPoolByNameOrID(ctx, s.namespace, s.transfer.Pool)
 		if err != nil {
@@ -274,10 +257,23 @@ func (s *transferSender) sendInternal(ctx context.Context, method sendMethod) er
 			return i18n.NewError(ctx, i18n.MsgTokenPoolNotConfirmed)
 		}
 
-		err = s.mgr.database.UpsertTransaction(ctx, tx)
+		txid, err := s.mgr.txHelper.SubmitNewTransaction(ctx, s.namespace, fftypes.TransactionTypeTokenTransfer)
 		if err != nil {
 			return err
 		}
+
+		s.transfer.TX.ID = txid
+		s.transfer.TX.Type = fftypes.TransactionTypeTokenTransfer
+
+		op = fftypes.NewTXOperation(
+			plugin,
+			s.namespace,
+			txid,
+			"",
+			fftypes.OpTypeTokenTransfer,
+			fftypes.OpStatusPending)
+		txcommon.AddTokenTransferInputs(op, &s.transfer.TokenTransfer)
+
 		if err = s.mgr.database.InsertOperation(ctx, op); err != nil {
 			return err
 		}
@@ -308,9 +304,6 @@ func (s *transferSender) sendInternal(ctx context.Context, method sendMethod) er
 			l := log.L(ctx)
 			update := database.OperationQueryFactory.NewUpdate(ctx).
 				Set("status", fftypes.OpStatusFailed)
-			if err = s.mgr.database.UpdateTransaction(ctx, tx.ID, update); err != nil {
-				l.Errorf("TX update failed: %s update=[ %s ]", err, update)
-			}
 			if err = s.mgr.database.UpdateOperation(ctx, op.ID, update); err != nil {
 				l.Errorf("Operation update failed: %s update=[ %s ]", err, update)
 			}

--- a/internal/assets/token_transfer_test.go
+++ b/internal/assets/token_transfer_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hyperledger/firefly/mocks/syncasyncmocks"
 	"github.com/hyperledger/firefly/mocks/sysmessagingmocks"
 	"github.com/hyperledger/firefly/mocks/tokenmocks"
+	"github.com/hyperledger/firefly/mocks/txcommonmocks"
 	"github.com/hyperledger/firefly/pkg/database"
 	"github.com/hyperledger/firefly/pkg/fftypes"
 	"github.com/hyperledger/firefly/pkg/tokens"
@@ -124,12 +125,11 @@ func TestMintTokensSuccess(t *testing.T) {
 	mdi := am.database.(*databasemocks.Plugin)
 	mti := am.tokens["magic-tokens"].(*tokenmocks.Plugin)
 	mim := am.identity.(*identitymanagermocks.Manager)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mim.On("GetLocalOrganization", context.Background()).Return(&fftypes.Organization{Identity: "0x12345"}, nil)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
 	mti.On("MintTokens", context.Background(), mock.Anything, "F1", &mint.TokenTransfer).Return(nil)
-	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
-		return tx.Type == fftypes.TransactionTypeTokenTransfer
-	})).Return(nil)
+	mth.On("SubmitNewTransaction", context.Background(), "ns1", fftypes.TransactionTypeTokenTransfer).Return(fftypes.NewUUID(), nil)
 	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 
 	_, err := am.MintTokens(context.Background(), "ns1", mint, false)
@@ -154,12 +154,11 @@ func TestMintTokenUnknownConnectorSuccess(t *testing.T) {
 	mdi := am.database.(*databasemocks.Plugin)
 	mti := am.tokens["magic-tokens"].(*tokenmocks.Plugin)
 	mim := am.identity.(*identitymanagermocks.Manager)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mim.On("GetLocalOrganization", context.Background()).Return(&fftypes.Organization{Identity: "0x12345"}, nil)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
 	mti.On("MintTokens", context.Background(), mock.Anything, "F1", &mint.TokenTransfer).Return(nil)
-	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
-		return tx.Type == fftypes.TransactionTypeTokenTransfer
-	})).Return(nil)
+	mth.On("SubmitNewTransaction", context.Background(), "ns1", fftypes.TransactionTypeTokenTransfer).Return(fftypes.NewUUID(), nil)
 	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 
 	_, err := am.MintTokens(context.Background(), "ns1", mint, false)
@@ -257,6 +256,7 @@ func TestMintTokenUnknownPoolSuccess(t *testing.T) {
 	mdi := am.database.(*databasemocks.Plugin)
 	mti := am.tokens["magic-tokens"].(*tokenmocks.Plugin)
 	mim := am.identity.(*identitymanagermocks.Manager)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	fb := database.TokenPoolQueryFactory.NewFilter(context.Background())
 	f := fb.And()
 	f.Limit(1).Count(true)
@@ -278,9 +278,7 @@ func TestMintTokenUnknownPoolSuccess(t *testing.T) {
 	}))).Return(tokenPools, filterResult, nil)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(tokenPools[0], nil)
 	mti.On("MintTokens", context.Background(), mock.Anything, "F1", &mint.TokenTransfer).Return(nil)
-	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
-		return tx.Type == fftypes.TransactionTypeTokenTransfer
-	})).Return(nil)
+	mth.On("SubmitNewTransaction", context.Background(), "ns1", fftypes.TransactionTypeTokenTransfer).Return(fftypes.NewUUID(), nil)
 	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 
 	_, err := am.MintTokens(context.Background(), "ns1", mint, false)
@@ -447,12 +445,11 @@ func TestMintTokensFail(t *testing.T) {
 	mdi := am.database.(*databasemocks.Plugin)
 	mti := am.tokens["magic-tokens"].(*tokenmocks.Plugin)
 	mim := am.identity.(*identitymanagermocks.Manager)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mim.On("GetLocalOrganization", context.Background()).Return(&fftypes.Organization{Identity: "0x12345"}, nil)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
 	mti.On("MintTokens", context.Background(), mock.Anything, "F1", &mint.TokenTransfer).Return(fmt.Errorf("pop"))
-	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
-		return tx.Type == fftypes.TransactionTypeTokenTransfer
-	})).Return(nil)
+	mth.On("SubmitNewTransaction", context.Background(), "ns1", fftypes.TransactionTypeTokenTransfer).Return(fftypes.NewUUID(), nil)
 	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 	mdi.On("UpdateTransaction", context.Background(), mock.Anything, mock.Anything).Return(nil)
 	mdi.On("UpdateOperation", context.Background(), mock.Anything, mock.Anything).Return(nil)
@@ -479,13 +476,12 @@ func TestMintTokensFailAndDbFail(t *testing.T) {
 	mdi := am.database.(*databasemocks.Plugin)
 	mti := am.tokens["magic-tokens"].(*tokenmocks.Plugin)
 	mim := am.identity.(*identitymanagermocks.Manager)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mim.On("GetLocalOrganization", context.Background()).Return(&fftypes.Organization{Identity: "0x12345"}, nil)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
 	mti.On("MintTokens", context.Background(), mock.Anything, "F1", &mint.TokenTransfer).Return(fmt.Errorf("pop"))
 	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
-	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
-		return tx.Type == fftypes.TransactionTypeTokenTransfer
-	})).Return(nil)
+	mth.On("SubmitNewTransaction", context.Background(), "ns1", fftypes.TransactionTypeTokenTransfer).Return(fftypes.NewUUID(), nil)
 	mdi.On("UpdateTransaction", context.Background(), mock.Anything, mock.Anything).Return(fmt.Errorf("Update fail"))
 	mdi.On("UpdateOperation", context.Background(), mock.Anything, mock.Anything).Return(fmt.Errorf("Update fail"))
 
@@ -510,11 +506,10 @@ func TestMintTokensOperationFail(t *testing.T) {
 
 	mdi := am.database.(*databasemocks.Plugin)
 	mim := am.identity.(*identitymanagermocks.Manager)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mim.On("GetLocalOrganization", context.Background()).Return(&fftypes.Organization{Identity: "0x12345"}, nil)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
-	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
-		return tx.Type == fftypes.TransactionTypeTokenTransfer
-	})).Return(nil)
+	mth.On("SubmitNewTransaction", context.Background(), "ns1", fftypes.TransactionTypeTokenTransfer).Return(fftypes.NewUUID(), nil)
 	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(fmt.Errorf("pop"))
 
 	_, err := am.MintTokens(context.Background(), "ns1", mint, false)
@@ -541,12 +536,11 @@ func TestMintTokensConfirm(t *testing.T) {
 	msa := am.syncasync.(*syncasyncmocks.Bridge)
 	mti := am.tokens["magic-tokens"].(*tokenmocks.Plugin)
 	mim := am.identity.(*identitymanagermocks.Manager)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mim.On("GetLocalOrganization", context.Background()).Return(&fftypes.Organization{Identity: "0x12345"}, nil)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
 	mti.On("MintTokens", context.Background(), mock.Anything, "F1", &mint.TokenTransfer).Return(nil)
-	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
-		return tx.Type == fftypes.TransactionTypeTokenTransfer
-	})).Return(nil)
+	mth.On("SubmitNewTransaction", context.Background(), "ns1", fftypes.TransactionTypeTokenTransfer).Return(fftypes.NewUUID(), nil)
 	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 	msa.On("WaitForTokenTransfer", context.Background(), "ns1", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
@@ -581,12 +575,11 @@ func TestMintTokensByTypeSuccess(t *testing.T) {
 	mdi := am.database.(*databasemocks.Plugin)
 	mti := am.tokens["magic-tokens"].(*tokenmocks.Plugin)
 	mim := am.identity.(*identitymanagermocks.Manager)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mim.On("GetLocalOrganization", context.Background()).Return(&fftypes.Organization{Identity: "0x12345"}, nil)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
 	mti.On("MintTokens", context.Background(), mock.Anything, "F1", &mint.TokenTransfer).Return(nil)
-	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
-		return tx.Type == fftypes.TransactionTypeTokenTransfer
-	})).Return(nil)
+	mth.On("SubmitNewTransaction", context.Background(), "ns1", fftypes.TransactionTypeTokenTransfer).Return(fftypes.NewUUID(), nil)
 	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 
 	_, err := am.MintTokensByType(context.Background(), "ns1", "magic-tokens", "pool1", mint, false)
@@ -611,12 +604,11 @@ func TestBurnTokensSuccess(t *testing.T) {
 	mdi := am.database.(*databasemocks.Plugin)
 	mti := am.tokens["magic-tokens"].(*tokenmocks.Plugin)
 	mim := am.identity.(*identitymanagermocks.Manager)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mim.On("GetLocalOrganization", context.Background()).Return(&fftypes.Organization{Identity: "0x12345"}, nil)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
 	mti.On("BurnTokens", context.Background(), mock.Anything, "F1", &burn.TokenTransfer).Return(nil)
-	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
-		return tx.Type == fftypes.TransactionTypeTokenTransfer
-	})).Return(nil)
+	mth.On("SubmitNewTransaction", context.Background(), "ns1", fftypes.TransactionTypeTokenTransfer).Return(fftypes.NewUUID(), nil)
 	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 
 	_, err := am.BurnTokens(context.Background(), "ns1", burn, false)
@@ -665,12 +657,11 @@ func TestBurnTokensConfirm(t *testing.T) {
 	msa := am.syncasync.(*syncasyncmocks.Bridge)
 	mti := am.tokens["magic-tokens"].(*tokenmocks.Plugin)
 	mim := am.identity.(*identitymanagermocks.Manager)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mim.On("GetLocalOrganization", context.Background()).Return(&fftypes.Organization{Identity: "0x12345"}, nil)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
 	mti.On("BurnTokens", context.Background(), mock.Anything, "F1", &burn.TokenTransfer).Return(nil)
-	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
-		return tx.Type == fftypes.TransactionTypeTokenTransfer
-	})).Return(nil)
+	mth.On("SubmitNewTransaction", context.Background(), "ns1", fftypes.TransactionTypeTokenTransfer).Return(fftypes.NewUUID(), nil)
 	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 	msa.On("WaitForTokenTransfer", context.Background(), "ns1", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
@@ -705,12 +696,11 @@ func TestBurnTokensByTypeSuccess(t *testing.T) {
 	mdi := am.database.(*databasemocks.Plugin)
 	mti := am.tokens["magic-tokens"].(*tokenmocks.Plugin)
 	mim := am.identity.(*identitymanagermocks.Manager)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mim.On("GetLocalOrganization", context.Background()).Return(&fftypes.Organization{Identity: "0x12345"}, nil)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
 	mti.On("BurnTokens", context.Background(), mock.Anything, "F1", &burn.TokenTransfer).Return(nil)
-	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
-		return tx.Type == fftypes.TransactionTypeTokenTransfer
-	})).Return(nil)
+	mth.On("SubmitNewTransaction", context.Background(), "ns1", fftypes.TransactionTypeTokenTransfer).Return(fftypes.NewUUID(), nil)
 	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 
 	_, err := am.BurnTokensByType(context.Background(), "ns1", "magic-tokens", "pool1", burn, false)
@@ -741,12 +731,11 @@ func TestTransferTokensSuccess(t *testing.T) {
 	mdi := am.database.(*databasemocks.Plugin)
 	mti := am.tokens["magic-tokens"].(*tokenmocks.Plugin)
 	mim := am.identity.(*identitymanagermocks.Manager)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mim.On("GetLocalOrganization", context.Background()).Return(&fftypes.Organization{Identity: "0x12345"}, nil)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
 	mti.On("TransferTokens", context.Background(), mock.Anything, "F1", &transfer.TokenTransfer).Return(nil)
-	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
-		return tx.Type == fftypes.TransactionTypeTokenTransfer
-	})).Return(nil)
+	mth.On("SubmitNewTransaction", context.Background(), "ns1", fftypes.TransactionTypeTokenTransfer).Return(fftypes.NewUUID(), nil)
 	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 
 	_, err := am.TransferTokens(context.Background(), "ns1", transfer, false)
@@ -842,10 +831,9 @@ func TestTransferTokensInvalidType(t *testing.T) {
 	}
 
 	mdi := am.database.(*databasemocks.Plugin)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mdi.On("GetTokenPool", am.ctx, "ns1", "pool1").Return(pool, nil)
-	mdi.On("UpsertTransaction", am.ctx, mock.MatchedBy(func(tx *fftypes.Transaction) bool {
-		return tx.Type == fftypes.TransactionTypeTokenTransfer
-	})).Return(nil)
+	mth.On("SubmitNewTransaction", am.ctx, "ns1", fftypes.TransactionTypeTokenTransfer).Return(fftypes.NewUUID(), nil)
 	mdi.On("InsertOperation", am.ctx, mock.Anything).Return(nil)
 
 	sender := &transferSender{
@@ -877,11 +865,10 @@ func TestTransferTokensTransactionFail(t *testing.T) {
 
 	mdi := am.database.(*databasemocks.Plugin)
 	mim := am.identity.(*identitymanagermocks.Manager)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mim.On("GetLocalOrganization", context.Background()).Return(&fftypes.Organization{Identity: "0x12345"}, nil)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
-	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
-		return tx.Type == fftypes.TransactionTypeTokenTransfer
-	})).Return(fmt.Errorf("pop"))
+	mth.On("SubmitNewTransaction", context.Background(), "ns1", fftypes.TransactionTypeTokenTransfer).Return(nil, fmt.Errorf("pop"))
 
 	_, err := am.TransferTokens(context.Background(), "ns1", transfer, false)
 	assert.EqualError(t, err, "pop")
@@ -927,12 +914,11 @@ func TestTransferTokensWithBroadcastMessage(t *testing.T) {
 	mim := am.identity.(*identitymanagermocks.Manager)
 	mbm := am.broadcast.(*broadcastmocks.Manager)
 	mms := &sysmessagingmocks.MessageSender{}
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mim.On("GetLocalOrganization", context.Background()).Return(&fftypes.Organization{Identity: "0x12345"}, nil)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
 	mti.On("TransferTokens", context.Background(), mock.Anything, "F1", &transfer.TokenTransfer).Return(nil)
-	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
-		return tx.Type == fftypes.TransactionTypeTokenTransfer
-	})).Return(nil)
+	mth.On("SubmitNewTransaction", context.Background(), "ns1", fftypes.TransactionTypeTokenTransfer).Return(fftypes.NewUUID(), nil)
 	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 	mbm.On("NewBroadcast", "ns1", transfer.Message).Return(mms)
 	mms.On("Prepare", context.Background()).Return(nil)
@@ -1025,12 +1011,11 @@ func TestTransferTokensWithPrivateMessage(t *testing.T) {
 	mim := am.identity.(*identitymanagermocks.Manager)
 	mpm := am.messaging.(*privatemessagingmocks.Manager)
 	mms := &sysmessagingmocks.MessageSender{}
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mim.On("GetLocalOrganization", context.Background()).Return(&fftypes.Organization{Identity: "0x12345"}, nil)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
 	mti.On("TransferTokens", context.Background(), mock.Anything, "F1", &transfer.TokenTransfer).Return(nil)
-	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
-		return tx.Type == fftypes.TransactionTypeTokenTransfer
-	})).Return(nil)
+	mth.On("SubmitNewTransaction", context.Background(), "ns1", fftypes.TransactionTypeTokenTransfer).Return(fftypes.NewUUID(), nil)
 	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 	mpm.On("NewMessage", "ns1", transfer.Message).Return(mms)
 	mms.On("Prepare", context.Background()).Return(nil)
@@ -1106,12 +1091,11 @@ func TestTransferTokensConfirm(t *testing.T) {
 	msa := am.syncasync.(*syncasyncmocks.Bridge)
 	mti := am.tokens["magic-tokens"].(*tokenmocks.Plugin)
 	mim := am.identity.(*identitymanagermocks.Manager)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mim.On("GetLocalOrganization", context.Background()).Return(&fftypes.Organization{Identity: "0x12345"}, nil)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
 	mti.On("TransferTokens", context.Background(), mock.Anything, "F1", &transfer.TokenTransfer).Return(nil)
-	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
-		return tx.Type == fftypes.TransactionTypeTokenTransfer
-	})).Return(nil)
+	mth.On("SubmitNewTransaction", context.Background(), "ns1", fftypes.TransactionTypeTokenTransfer).Return(fftypes.NewUUID(), nil)
 	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 	msa.On("WaitForTokenTransfer", context.Background(), "ns1", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
@@ -1167,13 +1151,12 @@ func TestTransferTokensWithBroadcastConfirm(t *testing.T) {
 	mbm := am.broadcast.(*broadcastmocks.Manager)
 	mms := &sysmessagingmocks.MessageSender{}
 	msa := am.syncasync.(*syncasyncmocks.Bridge)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mim.On("GetLocalOrganization", context.Background()).Return(&fftypes.Organization{Identity: "0x12345"}, nil)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
 	mti.On("TransferTokens", context.Background(), mock.Anything, "F1", &transfer.TokenTransfer).Return(nil)
 	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
-	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
-		return tx.Type == fftypes.TransactionTypeTokenTransfer
-	})).Return(nil)
+	mth.On("SubmitNewTransaction", context.Background(), "ns1", fftypes.TransactionTypeTokenTransfer).Return(fftypes.NewUUID(), nil)
 	mbm.On("NewBroadcast", "ns1", transfer.Message).Return(mms)
 	mms.On("Prepare", context.Background()).Return(nil)
 	mdi.On("UpsertMessage", context.Background(), mock.MatchedBy(func(msg *fftypes.Message) bool {
@@ -1224,12 +1207,11 @@ func TestTransferTokensByTypeSuccess(t *testing.T) {
 	mdi := am.database.(*databasemocks.Plugin)
 	mti := am.tokens["magic-tokens"].(*tokenmocks.Plugin)
 	mim := am.identity.(*identitymanagermocks.Manager)
+	mth := am.txHelper.(*txcommonmocks.Helper)
 	mim.On("GetLocalOrganization", context.Background()).Return(&fftypes.Organization{Identity: "0x12345"}, nil)
 	mdi.On("GetTokenPool", context.Background(), "ns1", "pool1").Return(pool, nil)
 	mti.On("TransferTokens", context.Background(), mock.Anything, "F1", &transfer.TokenTransfer).Return(nil)
-	mdi.On("UpsertTransaction", context.Background(), mock.MatchedBy(func(tx *fftypes.Transaction) bool {
-		return tx.Type == fftypes.TransactionTypeTokenTransfer
-	})).Return(nil)
+	mth.On("SubmitNewTransaction", context.Background(), "ns1", fftypes.TransactionTypeTokenTransfer).Return(fftypes.NewUUID(), nil)
 	mdi.On("InsertOperation", context.Background(), mock.Anything).Return(nil)
 
 	_, err := am.TransferTokensByType(context.Background(), "ns1", "magic-tokens", "pool1", transfer, false)

--- a/internal/batch/batch_manager_test.go
+++ b/internal/batch/batch_manager_test.go
@@ -118,6 +118,8 @@ func TestE2EDispatchBroadcast(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("id IN ['%s']", msg.Header.ID.String()), fi.String())
 		return true
 	}), mock.Anything).Return(nil)
+	mdi.On("InsertTransaction", mock.Anything, mock.Anything).Return(nil)
+	mdi.On("InsertEvent", mock.Anything, mock.Anything).Return(nil) // transaction submit
 
 	err := bm.Start()
 	assert.NoError(t, err)
@@ -231,6 +233,8 @@ func TestE2EDispatchPrivate(t *testing.T) {
 		a[1].(*fftypes.Nonce).Nonce = nextNonce
 		nextNonce++
 	}
+	mdi.On("InsertTransaction", mock.Anything, mock.Anything).Return(nil)
+	mdi.On("InsertEvent", mock.Anything, mock.Anything).Return(nil) // transaction submit
 
 	err := bm.Start()
 	assert.NoError(t, err)

--- a/internal/batch/batch_processor_test.go
+++ b/internal/batch/batch_processor_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hyperledger/firefly/internal/retry"
 	"github.com/hyperledger/firefly/mocks/databasemocks"
 	"github.com/hyperledger/firefly/mocks/sysmessagingmocks"
+	"github.com/hyperledger/firefly/mocks/txcommonmocks"
 	"github.com/hyperledger/firefly/pkg/fftypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -49,6 +50,7 @@ func newTestBatchProcessor(dispatch DispatchHandler) (*databasemocks.Plugin, *ba
 		InitialDelay: 1 * time.Microsecond,
 		MaximumDelay: 1 * time.Microsecond,
 	})
+	bp.txHelper = &txcommonmocks.Helper{}
 	return mdi, bp
 }
 
@@ -76,6 +78,9 @@ func TestUnfilledBatch(t *testing.T) {
 	mdi.On("UpdateMessages", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mdi.On("UpsertBatch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mdi.On("UpdateBatch", mock.Anything, mock.Anything).Return(nil)
+
+	mth := bp.txHelper.(*txcommonmocks.Helper)
+	mth.On("SubmitNewTransaction", mock.Anything, "ns1", fftypes.TransactionTypeBatchPin).Return(fftypes.NewUUID(), nil)
 
 	// Generate the work
 	work := make([]*batchWork, 5)
@@ -128,6 +133,9 @@ func TestBatchSizeOverflow(t *testing.T) {
 	mdi.On("UpdateMessages", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mdi.On("UpsertBatch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mdi.On("UpdateBatch", mock.Anything, mock.Anything).Return(nil)
+
+	mth := bp.txHelper.(*txcommonmocks.Helper)
+	mth.On("SubmitNewTransaction", mock.Anything, "ns1", fftypes.TransactionTypeBatchPin).Return(fftypes.NewUUID(), nil)
 
 	// Generate the work
 	work := make([]*batchWork, 2)
@@ -184,6 +192,9 @@ func TestFilledBatchSlowPersistence(t *testing.T) {
 	mockRunAsGroupPassthrough(mdi)
 	mdi.On("UpdateMessages", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mdi.On("UpdateBatch", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	mth := bp.txHelper.(*txcommonmocks.Helper)
+	mth.On("SubmitNewTransaction", mock.Anything, "ns1", fftypes.TransactionTypeBatchPin).Return(fftypes.NewUUID(), nil)
 
 	// Generate the work
 	work := make([]*batchWork, 10)

--- a/internal/batchpin/batchpin.go
+++ b/internal/batchpin/batchpin.go
@@ -48,16 +48,6 @@ func NewBatchPinSubmitter(di database.Plugin, im identity.Manager, bi blockchain
 }
 
 func (bp *batchPinSubmitter) SubmitPinnedBatch(ctx context.Context, batch *fftypes.Batch, contexts []*fftypes.Bytes32) error {
-	tx := &fftypes.Transaction{
-		ID:        batch.Payload.TX.ID,
-		Type:      fftypes.TransactionTypeBatchPin,
-		Namespace: batch.Namespace,
-		Created:   fftypes.Now(),
-	}
-	err := bp.database.UpsertTransaction(ctx, tx)
-	if err != nil {
-		return err
-	}
 
 	// The pending blockchain transaction
 	op := fftypes.NewTXOperation(
@@ -67,8 +57,7 @@ func (bp *batchPinSubmitter) SubmitPinnedBatch(ctx context.Context, batch *fftyp
 		"",
 		fftypes.OpTypeBlockchainBatchPin,
 		fftypes.OpStatusPending)
-	err = bp.database.InsertOperation(ctx, op)
-	if err != nil {
+	if err := bp.database.InsertOperation(ctx, op); err != nil {
 		return err
 	}
 

--- a/internal/contracts/manager.go
+++ b/internal/contracts/manager.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hyperledger/firefly/internal/broadcast"
 	"github.com/hyperledger/firefly/internal/i18n"
 	"github.com/hyperledger/firefly/internal/identity"
+	"github.com/hyperledger/firefly/internal/txcommon"
 	"github.com/hyperledger/firefly/pkg/blockchain"
 	"github.com/hyperledger/firefly/pkg/database"
 	"github.com/hyperledger/firefly/pkg/fftypes"
@@ -56,6 +57,7 @@ type Manager interface {
 
 type contractManager struct {
 	database          database.Plugin
+	txHelper          txcommon.Helper
 	publicStorage     publicstorage.Plugin
 	broadcast         broadcast.Manager
 	identity          identity.Manager
@@ -73,6 +75,7 @@ func NewContractManager(ctx context.Context, database database.Plugin, publicSto
 	}
 	return &contractManager{
 		database:          database,
+		txHelper:          txcommon.NewTransactionHelper(database),
 		publicStorage:     publicStorage,
 		broadcast:         broadcast,
 		identity:          identity,
@@ -175,20 +178,15 @@ func (cm *contractManager) InvokeContract(ctx context.Context, ns string, req *f
 			return err
 		}
 
-		tx := &fftypes.Transaction{
-			ID:        fftypes.NewUUID(),
-			Namespace: ns,
-			Type:      fftypes.TransactionTypeContractInvoke,
-			Created:   fftypes.Now(),
-		}
-		if err := cm.database.UpsertTransaction(ctx, tx); err != nil {
+		txid, err := cm.txHelper.SubmitNewTransaction(ctx, ns, fftypes.TransactionTypeContractInvoke)
+		if err != nil {
 			return err
 		}
 
 		op = fftypes.NewTXOperation(
 			cm.blockchain,
 			ns,
-			tx.ID,
+			txid,
 			"",
 			fftypes.OpTypeContractInvoke,
 			fftypes.OpStatusPending)

--- a/internal/database/sqlcommon/transaction_sql.go
+++ b/internal/database/sqlcommon/transaction_sql.go
@@ -41,62 +41,29 @@ var (
 	}
 )
 
-func (s *SQLCommon) UpsertTransaction(ctx context.Context, transaction *fftypes.Transaction) (err error) {
+func (s *SQLCommon) InsertTransaction(ctx context.Context, transaction *fftypes.Transaction) (err error) {
 	ctx, tx, autoCommit, err := s.beginOrUseTx(ctx)
 	if err != nil {
 		return err
 	}
 	defer s.rollbackTx(ctx, tx, autoCommit)
 
-	// Do a select within the transaction to determine if the UUID already exists
-	transactionRows, _, err := s.queryTx(ctx, tx,
-		sq.Select("blockchain_ids").
-			From("transactions").
-			Where(sq.Eq{"id": transaction.ID}),
-	)
-	if err != nil {
+	transaction.Created = fftypes.Now()
+	if _, err = s.insertTx(ctx, tx,
+		sq.Insert("transactions").
+			Columns(transactionColumns...).
+			Values(
+				transaction.ID,
+				string(transaction.Type),
+				transaction.Namespace,
+				transaction.Created,
+				transaction.BlockchainIDs,
+			),
+		func() {
+			s.callbacks.UUIDCollectionNSEvent(database.CollectionTransactions, fftypes.ChangeEventTypeCreated, transaction.Namespace, transaction.ID)
+		},
+	); err != nil {
 		return err
-	}
-	existing := transactionRows.Next()
-
-	if existing {
-		var existingBlockchainIDs fftypes.FFStringArray
-		_ = transactionRows.Scan(&existingBlockchainIDs)
-		transaction.BlockchainIDs = transaction.BlockchainIDs.MergeLower(existingBlockchainIDs)
-		transactionRows.Close()
-		// Update the transaction
-		if _, err = s.updateTx(ctx, tx,
-			sq.Update("transactions").
-				Set("ttype", string(transaction.Type)).
-				Set("namespace", transaction.Namespace).
-				Set("blockchain_ids", transaction.BlockchainIDs).
-				Where(sq.Eq{"id": transaction.ID}),
-			func() {
-				s.callbacks.UUIDCollectionNSEvent(database.CollectionTransactions, fftypes.ChangeEventTypeUpdated, transaction.Namespace, transaction.ID)
-			},
-		); err != nil {
-			return err
-		}
-	} else {
-		transactionRows.Close()
-		// Insert a transaction
-		transaction.Created = fftypes.Now()
-		if _, err = s.insertTx(ctx, tx,
-			sq.Insert("transactions").
-				Columns(transactionColumns...).
-				Values(
-					transaction.ID,
-					string(transaction.Type),
-					transaction.Namespace,
-					transaction.Created,
-					transaction.BlockchainIDs,
-				),
-			func() {
-				s.callbacks.UUIDCollectionNSEvent(database.CollectionTransactions, fftypes.ChangeEventTypeCreated, transaction.Namespace, transaction.ID)
-			},
-		); err != nil {
-			return err
-		}
 	}
 
 	return s.commitTx(ctx, tx, autoCommit)

--- a/internal/database/sqlcommon/transaction_sql_test.go
+++ b/internal/database/sqlcommon/transaction_sql_test.go
@@ -47,7 +47,7 @@ func TestTransactionE2EWithDB(t *testing.T) {
 	s.callbacks.On("UUIDCollectionNSEvent", database.CollectionTransactions, fftypes.ChangeEventTypeCreated, "ns1", transactionID, mock.Anything).Return()
 	s.callbacks.On("UUIDCollectionNSEvent", database.CollectionTransactions, fftypes.ChangeEventTypeUpdated, "ns1", transactionID, mock.Anything).Return()
 
-	err := s.UpsertTransaction(ctx, transaction)
+	err := s.InsertTransaction(ctx, transaction)
 	assert.NoError(t, err)
 
 	// Check we get the exact same transaction back
@@ -58,31 +58,10 @@ func TestTransactionE2EWithDB(t *testing.T) {
 	transactionReadJson, _ := json.Marshal(&transactionRead)
 	assert.Equal(t, string(transactionJson), string(transactionReadJson))
 
-	// Update the transaction
-	transactionUpdated := &fftypes.Transaction{
-		ID:            transactionID,
-		Type:          fftypes.TransactionTypeBatchPin,
-		Namespace:     "ns1",
-		Created:       transaction.Created,
-		BlockchainIDs: fftypes.FFStringArray{"tx2", "tx3"}, // additive
-	}
-	err = s.UpsertTransaction(context.Background(), transactionUpdated)
-	assert.NoError(t, err)
-
-	// Expect merged
-	transactionUpdated.BlockchainIDs = fftypes.FFStringArray{"tx1", "tx2", "tx3"}
-
-	// Check we get the exact same message back - note the removal of one of the transaction elements
-	transactionRead, err = s.GetTransactionByID(ctx, transactionID)
-	assert.NoError(t, err)
-	transactionJson, _ = json.Marshal(&transactionUpdated)
-	transactionReadJson, _ = json.Marshal(&transactionRead)
-	assert.Equal(t, string(transactionJson), string(transactionReadJson))
-
 	// Query back the transaction
 	fb := database.TransactionQueryFactory.NewFilter(ctx)
 	filter := fb.And(
-		fb.Eq("id", transactionUpdated.ID.String()),
+		fb.Eq("id", transaction.ID.String()),
 		fb.Gt("created", "0"),
 	)
 	transactions, res, err := s.GetTransactions(ctx, filter.Count(true))
@@ -94,7 +73,7 @@ func TestTransactionE2EWithDB(t *testing.T) {
 
 	// Negative test on filter
 	filter = fb.And(
-		fb.Eq("id", transactionUpdated.ID.String()),
+		fb.Eq("id", transaction.ID.String()),
 		fb.Eq("created", "0"),
 	)
 	transactions, _, err = s.GetTransactions(ctx, filter)
@@ -103,71 +82,46 @@ func TestTransactionE2EWithDB(t *testing.T) {
 
 	// Update
 	up := database.TransactionQueryFactory.NewUpdate(ctx).
-		Set("blockchainids", fftypes.FFStringArray{"0x12345"})
-	err = s.UpdateTransaction(ctx, transactionUpdated.ID, up)
+		Set("blockchainids", fftypes.FFStringArray{"0x12345", "0x23456"})
+	err = s.UpdateTransaction(ctx, transaction.ID, up)
 	assert.NoError(t, err)
 
 	// Test find updated value
 	filter = fb.And(
-		fb.Eq("id", transactionUpdated.ID.String()),
-		fb.Eq("blockchainids", "0x12345"),
+		fb.Eq("id", transaction.ID.String()),
+		fb.Eq("blockchainids", "0x12345,0x23456"),
 	)
 	transactions, _, err = s.GetTransactions(ctx, filter)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(transactions))
 }
 
-func TestUpsertTransactionFailBegin(t *testing.T) {
+func TestInsertTransactionFailBegin(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin().WillReturnError(fmt.Errorf("pop"))
-	err := s.UpsertTransaction(context.Background(), &fftypes.Transaction{})
+	err := s.InsertTransaction(context.Background(), &fftypes.Transaction{})
 	assert.Regexp(t, "FF10114", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestUpsertTransactionFailSelect(t *testing.T) {
+func TestInsertTransactionFailInsert(t *testing.T) {
 	s, mock := newMockProvider().init()
 	mock.ExpectBegin()
-	mock.ExpectQuery("SELECT .*").WillReturnError(fmt.Errorf("pop"))
-	mock.ExpectRollback()
-	transactionID := fftypes.NewUUID()
-	err := s.UpsertTransaction(context.Background(), &fftypes.Transaction{ID: transactionID})
-	assert.Regexp(t, "FF10115", err)
-	assert.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestUpsertTransactionFailInsert(t *testing.T) {
-	s, mock := newMockProvider().init()
-	mock.ExpectBegin()
-	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{}))
 	mock.ExpectExec("INSERT .*").WillReturnError(fmt.Errorf("pop"))
 	mock.ExpectRollback()
 	transactionID := fftypes.NewUUID()
-	err := s.UpsertTransaction(context.Background(), &fftypes.Transaction{ID: transactionID})
+	err := s.InsertTransaction(context.Background(), &fftypes.Transaction{ID: transactionID})
 	assert.Regexp(t, "FF10116", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestUpsertTransactionFailUpdate(t *testing.T) {
+func TestInsertTransactionFailCommit(t *testing.T) {
 	s, mock := newMockProvider().init()
 	transactionID := fftypes.NewUUID()
 	mock.ExpectBegin()
-	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(transactionID.String()))
-	mock.ExpectExec("UPDATE .*").WillReturnError(fmt.Errorf("pop"))
-	mock.ExpectRollback()
-	err := s.UpsertTransaction(context.Background(), &fftypes.Transaction{ID: transactionID})
-	assert.Regexp(t, "FF10117", err)
-	assert.NoError(t, mock.ExpectationsWereMet())
-}
-
-func TestUpsertTransactionFailCommit(t *testing.T) {
-	s, mock := newMockProvider().init()
-	transactionID := fftypes.NewUUID()
-	mock.ExpectBegin()
-	mock.ExpectQuery("SELECT .*").WillReturnRows(sqlmock.NewRows([]string{"id"}))
 	mock.ExpectExec("INSERT .*").WillReturnResult(sqlmock.NewResult(1, 1))
 	mock.ExpectCommit().WillReturnError(fmt.Errorf("pop"))
-	err := s.UpsertTransaction(context.Background(), &fftypes.Transaction{ID: transactionID})
+	err := s.InsertTransaction(context.Background(), &fftypes.Transaction{ID: transactionID})
 	assert.Regexp(t, "FF10119", err)
 	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/events/batch_pin_complete.go
+++ b/internal/events/batch_pin_complete.go
@@ -72,12 +72,8 @@ func (em *eventManager) handlePrivatePinComplete(batchPin *blockchain.BatchPin) 
 }
 
 func (em *eventManager) persistBatchTransaction(ctx context.Context, batchPin *blockchain.BatchPin) error {
-	return em.database.UpsertTransaction(ctx, &fftypes.Transaction{
-		ID:            batchPin.TransactionID,
-		Namespace:     batchPin.Namespace,
-		Type:          fftypes.TransactionTypeBatchPin,
-		BlockchainIDs: fftypes.NewFFStringArray(batchPin.Event.BlockchainTXID),
-	})
+	_, err := em.txHelper.PersistTransaction(ctx, batchPin.Namespace, batchPin.TransactionID, fftypes.TransactionTypeBatchPin, batchPin.Event.BlockchainTXID)
+	return err
 }
 
 func (em *eventManager) persistContexts(ctx context.Context, batchPin *blockchain.BatchPin, private bool) error {

--- a/internal/events/event_manager.go
+++ b/internal/events/event_manager.go
@@ -35,6 +35,7 @@ import (
 	"github.com/hyperledger/firefly/internal/privatemessaging"
 	"github.com/hyperledger/firefly/internal/retry"
 	"github.com/hyperledger/firefly/internal/sysmessaging"
+	"github.com/hyperledger/firefly/internal/txcommon"
 	"github.com/hyperledger/firefly/pkg/blockchain"
 	"github.com/hyperledger/firefly/pkg/database"
 	"github.com/hyperledger/firefly/pkg/dataexchange"
@@ -78,6 +79,7 @@ type eventManager struct {
 	ni                   sysmessaging.LocalNodeInfo
 	publicstorage        publicstorage.Plugin
 	database             database.Plugin
+	txHelper             txcommon.Helper
 	identity             identity.Manager
 	definitions          definitions.DefinitionHandlers
 	data                 data.Manager
@@ -105,6 +107,7 @@ func NewEventManager(ctx context.Context, ni sysmessaging.LocalNodeInfo, pi publ
 		ni:            ni,
 		publicstorage: pi,
 		database:      di,
+		txHelper:      txcommon.NewTransactionHelper(di),
 		identity:      im,
 		definitions:   dh,
 		data:          dm,

--- a/internal/events/event_manager_test.go
+++ b/internal/events/event_manager_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/hyperledger/firefly/mocks/privatemessagingmocks"
 	"github.com/hyperledger/firefly/mocks/publicstoragemocks"
 	"github.com/hyperledger/firefly/mocks/sysmessagingmocks"
+	"github.com/hyperledger/firefly/mocks/txcommonmocks"
 	"github.com/hyperledger/firefly/pkg/fftypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -57,6 +58,7 @@ func newTestEventManager(t *testing.T) (*eventManager, func()) {
 	met.On("Name").Return("ut").Maybe()
 	emi, err := NewEventManager(ctx, mni, mpi, mdi, mim, msh, mdm, mbm, mpm, mam)
 	em := emi.(*eventManager)
+	em.txHelper = &txcommonmocks.Helper{}
 	rag := mdi.On("RunAsGroup", em.ctx, mock.Anything).Maybe()
 	rag.RunFn = func(a mock.Arguments) {
 		rag.ReturnArguments = mock.Arguments{a[1].(func(context.Context) error)(a[0].(context.Context))}

--- a/internal/events/operation_update.go
+++ b/internal/events/operation_update.go
@@ -47,16 +47,7 @@ func (em *eventManager) operationUpdateCtx(ctx context.Context, operationID *fft
 		}
 	}
 
-	tx, err := em.database.GetTransactionByID(ctx, op.Transaction)
-	if tx != nil {
-		tx.BlockchainIDs = tx.BlockchainIDs.AppendLowerUnique(blockchainTXID)
-		err = em.database.UpsertTransaction(ctx, tx)
-	}
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return em.txHelper.AddBlockchainTX(ctx, op.Transaction, blockchainTXID)
 }
 
 func (em *eventManager) OperationUpdate(plugin fftypes.Named, operationID *fftypes.UUID, txState fftypes.OpStatus, blockchainTXID, errorMessage string, opOutput fftypes.JSONObject) error {

--- a/internal/events/operation_update_test.go
+++ b/internal/events/operation_update_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/hyperledger/firefly/mocks/blockchainmocks"
 	"github.com/hyperledger/firefly/mocks/databasemocks"
+	"github.com/hyperledger/firefly/mocks/txcommonmocks"
 	"github.com/hyperledger/firefly/pkg/fftypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -33,19 +34,19 @@ func TestOperationUpdateSuccess(t *testing.T) {
 	defer cancel()
 	mdi := em.database.(*databasemocks.Plugin)
 	mbi := &blockchainmocks.Plugin{}
+	mth := em.txHelper.(*txcommonmocks.Helper)
 
 	opID := fftypes.NewUUID()
 	txid := fftypes.NewUUID()
 	mdi.On("RunAsGroup", em.ctx, mock.Anything).Run(func(args mock.Arguments) {
 		args[1].(func(ctx context.Context) error)(em.ctx)
 	}).Return(nil)
-	mdi.On("GetOperationByID", em.ctx, opID).Return(&fftypes.Operation{ID: opID}, nil)
+	mdi.On("GetOperationByID", em.ctx, opID).Return(&fftypes.Operation{ID: opID, Transaction: txid}, nil)
 	mdi.On("UpdateOperation", em.ctx, opID, mock.Anything).Return(nil)
-	mdi.On("GetTransactionByID", em.ctx, mock.Anything).Return(&fftypes.Transaction{ID: txid}, nil)
-	mdi.On("UpsertTransaction", em.ctx, mock.Anything).Return(nil)
+	mth.On("AddBlockchainTX", mock.Anything, txid, "0x12345").Return(nil)
 
 	info := fftypes.JSONObject{"some": "info"}
-	err := em.OperationUpdate(mdi, opID, fftypes.OpStatusFailed, "", "some error", info)
+	err := em.OperationUpdate(mdi, opID, fftypes.OpStatusFailed, "0x12345", "some error", info)
 	assert.NoError(t, err)
 
 	mdi.AssertExpectations(t)
@@ -76,11 +77,33 @@ func TestOperationUpdateError(t *testing.T) {
 	mbi := &blockchainmocks.Plugin{}
 
 	opID := fftypes.NewUUID()
-	mdi.On("GetOperationByID", em.ctx, opID).Return(&fftypes.Operation{ID: opID}, nil)
+	txid := fftypes.NewUUID()
+	mdi.On("GetOperationByID", em.ctx, opID).Return(&fftypes.Operation{ID: opID, Transaction: txid}, nil)
 	mdi.On("UpdateOperation", em.ctx, opID, mock.Anything).Return(fmt.Errorf("pop"))
 
 	info := fftypes.JSONObject{"some": "info"}
-	err := em.operationUpdateCtx(em.ctx, opID, fftypes.OpStatusFailed, "", "some error", info)
+	err := em.operationUpdateCtx(em.ctx, opID, fftypes.OpStatusFailed, "0x12345", "some error", info)
+	assert.EqualError(t, err, "pop")
+
+	mdi.AssertExpectations(t)
+	mbi.AssertExpectations(t)
+}
+
+func TestOperationTXUpdateError(t *testing.T) {
+	em, cancel := newTestEventManager(t)
+	defer cancel()
+	mdi := em.database.(*databasemocks.Plugin)
+	mbi := &blockchainmocks.Plugin{}
+	mth := em.txHelper.(*txcommonmocks.Helper)
+
+	opID := fftypes.NewUUID()
+	txid := fftypes.NewUUID()
+	mdi.On("GetOperationByID", em.ctx, opID).Return(&fftypes.Operation{ID: opID, Transaction: txid}, nil)
+	mdi.On("UpdateOperation", em.ctx, opID, mock.Anything).Return(nil)
+	mth.On("AddBlockchainTX", mock.Anything, txid, "0x12345").Return(fmt.Errorf("pop"))
+
+	info := fftypes.JSONObject{"some": "info"}
+	err := em.operationUpdateCtx(em.ctx, opID, fftypes.OpStatusFailed, "0x12345", "some error", info)
 	assert.EqualError(t, err, "pop")
 
 	mdi.AssertExpectations(t)
@@ -92,11 +115,13 @@ func TestOperationUpdateTransferFail(t *testing.T) {
 	defer cancel()
 	mdi := em.database.(*databasemocks.Plugin)
 	mbi := &blockchainmocks.Plugin{}
+	mth := em.txHelper.(*txcommonmocks.Helper)
 
 	op := &fftypes.Operation{
-		ID:        fftypes.NewUUID(),
-		Type:      fftypes.OpTypeTokenTransfer,
-		Namespace: "ns1",
+		ID:          fftypes.NewUUID(),
+		Type:        fftypes.OpTypeTokenTransfer,
+		Namespace:   "ns1",
+		Transaction: fftypes.NewUUID(),
 	}
 
 	mdi.On("GetOperationByID", em.ctx, op.ID).Return(op, nil)
@@ -104,11 +129,10 @@ func TestOperationUpdateTransferFail(t *testing.T) {
 	mdi.On("InsertEvent", em.ctx, mock.MatchedBy(func(e *fftypes.Event) bool {
 		return e.Type == fftypes.EventTypeTransferOpFailed && e.Namespace == "ns1"
 	})).Return(nil)
-	mdi.On("GetTransactionByID", em.ctx, mock.Anything).Return(&fftypes.Transaction{ID: fftypes.NewUUID()}, nil)
-	mdi.On("UpsertTransaction", em.ctx, mock.Anything).Return(nil)
+	mth.On("AddBlockchainTX", mock.Anything, op.Transaction, "0x12345").Return(nil)
 
 	info := fftypes.JSONObject{"some": "info"}
-	err := em.operationUpdateCtx(em.ctx, op.ID, fftypes.OpStatusFailed, "", "some error", info)
+	err := em.operationUpdateCtx(em.ctx, op.ID, fftypes.OpStatusFailed, "0x12345", "some error", info)
 	assert.NoError(t, err)
 
 	mdi.AssertExpectations(t)
@@ -120,21 +144,22 @@ func TestOperationUpdateTransferTransactionFail(t *testing.T) {
 	defer cancel()
 	mdi := em.database.(*databasemocks.Plugin)
 	mbi := &blockchainmocks.Plugin{}
+	mth := em.txHelper.(*txcommonmocks.Helper)
 
 	op := &fftypes.Operation{
-		ID:        fftypes.NewUUID(),
-		Type:      fftypes.OpTypeTokenTransfer,
-		Namespace: "ns1",
+		ID:          fftypes.NewUUID(),
+		Type:        fftypes.OpTypeTokenTransfer,
+		Namespace:   "ns1",
+		Transaction: fftypes.NewUUID(),
 	}
 
 	mdi.On("GetOperationByID", em.ctx, op.ID).Return(op, nil)
 	mdi.On("UpdateOperation", em.ctx, op.ID, mock.Anything).Return(nil)
 	mdi.On("InsertEvent", em.ctx, mock.Anything).Return(nil)
-	mdi.On("GetTransactionByID", em.ctx, mock.Anything).Return(&fftypes.Transaction{ID: fftypes.NewUUID()}, nil)
-	mdi.On("UpsertTransaction", em.ctx, mock.Anything).Return(fmt.Errorf("pop"))
+	mth.On("AddBlockchainTX", mock.Anything, op.Transaction, "0x12345").Return(fmt.Errorf("pop"))
 
 	info := fftypes.JSONObject{"some": "info"}
-	err := em.operationUpdateCtx(em.ctx, op.ID, fftypes.OpStatusFailed, "", "some error", info)
+	err := em.operationUpdateCtx(em.ctx, op.ID, fftypes.OpStatusFailed, "0x12345", "some error", info)
 	assert.EqualError(t, err, "pop")
 
 	mdi.AssertExpectations(t)
@@ -160,7 +185,7 @@ func TestOperationUpdateTransferEventFail(t *testing.T) {
 	})).Return(fmt.Errorf("pop"))
 
 	info := fftypes.JSONObject{"some": "info"}
-	err := em.operationUpdateCtx(em.ctx, op.ID, fftypes.OpStatusFailed, "", "some error", info)
+	err := em.operationUpdateCtx(em.ctx, op.ID, fftypes.OpStatusFailed, "0x12345", "some error", info)
 	assert.EqualError(t, err, "pop")
 
 	mdi.AssertExpectations(t)

--- a/internal/events/token_pool_created.go
+++ b/internal/events/token_pool_created.go
@@ -41,22 +41,12 @@ func addPoolDetailsFromPlugin(ffPool *fftypes.TokenPool, pluginPool *tokens.Toke
 	}
 }
 
-func poolTransaction(pool *fftypes.TokenPool, blockchainTXID string) *fftypes.Transaction {
-	return &fftypes.Transaction{
-		ID:            pool.TX.ID,
-		Namespace:     pool.Namespace,
-		Type:          pool.TX.Type,
-		BlockchainIDs: fftypes.NewFFStringArray(blockchainTXID),
-	}
-}
-
 func (em *eventManager) confirmPool(ctx context.Context, pool *fftypes.TokenPool, ev *blockchain.Event, blockchainTXID string) error {
 	chainEvent := buildBlockchainEvent(pool.Namespace, nil, ev, &pool.TX)
 	if err := em.persistBlockchainEvent(ctx, chainEvent); err != nil {
 		return err
 	}
-	tx := poolTransaction(pool, blockchainTXID)
-	if err := em.database.UpsertTransaction(ctx, tx); err != nil {
+	if _, err := em.txHelper.PersistTransaction(ctx, pool.Namespace, pool.TX.ID, pool.TX.Type, blockchainTXID); err != nil {
 		return err
 	}
 	pool.State = fftypes.TokenPoolStateConfirmed

--- a/internal/events/tokens_transferred.go
+++ b/internal/events/tokens_transferred.go
@@ -78,14 +78,8 @@ func (em *eventManager) persistTokenTransfer(ctx context.Context, transfer *toke
 			return false, err
 		}
 
-		tx := &fftypes.Transaction{
-			ID:            transfer.TX.ID,
-			Namespace:     transfer.Namespace,
-			Type:          transfer.TX.Type,
-			BlockchainIDs: fftypes.NewFFStringArray(transfer.Event.BlockchainTXID),
-		}
-		if err := em.database.UpsertTransaction(ctx, tx); err != nil {
-			return false, err
+		if valid, err := em.txHelper.PersistTransaction(ctx, transfer.Namespace, transfer.TX.ID, transfer.TX.Type, transfer.Event.BlockchainTXID); err != nil || !valid {
+			return valid, err
 		}
 
 		// Some operations result in multiple transfer events - if the protocol ID was unique but the

--- a/internal/txcommon/txcommon.go
+++ b/internal/txcommon/txcommon.go
@@ -1,0 +1,132 @@
+// Copyright © 2022 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package txcommon
+
+import (
+	"context"
+	"strings"
+
+	"github.com/hyperledger/firefly/internal/log"
+	"github.com/hyperledger/firefly/pkg/database"
+	"github.com/hyperledger/firefly/pkg/fftypes"
+)
+
+type Helper interface {
+	SubmitNewTransaction(ctx context.Context, ns string, txType fftypes.TransactionType) (*fftypes.UUID, error)
+	PersistTransaction(ctx context.Context, ns string, id *fftypes.UUID, txType fftypes.TransactionType, blockchainTXID string) (valid bool, err error)
+	AddBlockchainTX(ctx context.Context, id *fftypes.UUID, blockchainTXID string) error
+}
+
+type transactionHelper struct {
+	database database.Plugin
+}
+
+func NewTransactionHelper(di database.Plugin) Helper {
+	return &transactionHelper{
+		database: di,
+	}
+}
+
+// SubmitNewTransaction is called when there is a new transaction being submitted by the local node
+func (t *transactionHelper) SubmitNewTransaction(ctx context.Context, ns string, txType fftypes.TransactionType) (*fftypes.UUID, error) {
+
+	tx := &fftypes.Transaction{
+		ID:        fftypes.NewUUID(),
+		Namespace: ns,
+		Type:      txType,
+	}
+
+	if err := t.database.InsertTransaction(ctx, tx); err != nil {
+		return nil, err
+	}
+
+	if err := t.database.InsertEvent(ctx, fftypes.NewEvent(fftypes.EventTypeTransactionSubmitted, tx.Namespace, tx.ID)); err != nil {
+		return nil, err
+	}
+
+	return tx.ID, nil
+}
+
+// PersistTransaction is called when we need to ensure a transaction exists in the DB, and optionally associate a new BlockchainTXID to it
+func (t *transactionHelper) PersistTransaction(ctx context.Context, ns string, id *fftypes.UUID, txType fftypes.TransactionType, blockchainTXID string) (valid bool, err error) {
+
+	tx, err := t.database.GetTransactionByID(ctx, id)
+	if err != nil {
+		return false, err
+	}
+
+	if tx != nil {
+
+		if tx.Namespace != ns {
+			log.L(ctx).Errorf("Namespace mismatch for transaction '%s' existing=%s new=%s", tx.ID, tx.Namespace, ns)
+			return false, nil
+		}
+
+		if tx.Type != txType {
+			log.L(ctx).Errorf("Type mismatch for transaction '%s' existing=%s new=%s", tx.ID, tx.Type, txType)
+			return false, nil
+		}
+
+		newBlockchainIDs, changed := tx.BlockchainIDs.AddToSortedSet(blockchainTXID)
+		if !changed {
+			return true, nil
+		}
+
+		if err = t.database.UpdateTransaction(ctx, tx.ID, database.TransactionQueryFactory.NewUpdate(ctx).Set("blockchainids", newBlockchainIDs)); err != nil {
+			return false, err
+		}
+
+	} else {
+
+		if err = t.database.InsertTransaction(ctx, &fftypes.Transaction{
+			ID:            id,
+			Namespace:     ns,
+			Type:          txType,
+			BlockchainIDs: fftypes.NewFFStringArray(strings.ToLower(blockchainTXID)),
+		}); err != nil {
+			return false, err
+		}
+
+	}
+
+	return true, nil
+}
+
+// AddBlockchainTX is called when we know the tranasction should exist, and we don't need any validation
+// just want to bolt an extra blockchain TXID on - if it's not there already.
+func (t *transactionHelper) AddBlockchainTX(ctx context.Context, id *fftypes.UUID, blockchainTXID string) error {
+
+	tx, err := t.database.GetTransactionByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if tx != nil {
+
+		newBlockchainIDs, changed := tx.BlockchainIDs.AddToSortedSet(blockchainTXID)
+		if !changed {
+			return nil
+		}
+
+		if err = t.database.UpdateTransaction(ctx, tx.ID, database.TransactionQueryFactory.NewUpdate(ctx).Set("blockchainids", newBlockchainIDs)); err != nil {
+			return err
+		}
+
+	}
+
+	return nil
+}

--- a/internal/txcommon/txcommon_test.go
+++ b/internal/txcommon/txcommon_test.go
@@ -1,0 +1,285 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package txcommon
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hyperledger/firefly/mocks/databasemocks"
+	"github.com/hyperledger/firefly/pkg/fftypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestSubmitNewTransactionOK(t *testing.T) {
+
+	mdi := &databasemocks.Plugin{}
+	txHelper := NewTransactionHelper(mdi)
+	ctx := context.Background()
+
+	var txidInserted *fftypes.UUID
+	mdi.On("InsertTransaction", ctx, mock.MatchedBy(func(transaction *fftypes.Transaction) bool {
+		txidInserted = transaction.ID
+		assert.NotNil(t, transaction.ID)
+		assert.Equal(t, "ns1", transaction.Namespace)
+		assert.Equal(t, fftypes.TransactionTypeBatchPin, transaction.Type)
+		assert.Empty(t, transaction.BlockchainIDs)
+		return true
+	})).Return(nil)
+	mdi.On("InsertEvent", ctx, mock.MatchedBy(func(e *fftypes.Event) bool {
+		return e.Type == fftypes.EventTypeTransactionSubmitted && e.Reference.Equals(txidInserted)
+	})).Return(nil)
+
+	txidReturned, err := txHelper.SubmitNewTransaction(ctx, "ns1", fftypes.TransactionTypeBatchPin)
+	assert.NoError(t, err)
+	assert.Equal(t, *txidInserted, *txidReturned)
+
+	mdi.AssertExpectations(t)
+
+}
+
+func TestSubmitNewTransactionFail(t *testing.T) {
+
+	mdi := &databasemocks.Plugin{}
+	txHelper := NewTransactionHelper(mdi)
+	ctx := context.Background()
+
+	mdi.On("InsertTransaction", ctx, mock.Anything).Return(fmt.Errorf("pop"))
+
+	_, err := txHelper.SubmitNewTransaction(ctx, "ns1", fftypes.TransactionTypeBatchPin)
+	assert.Regexp(t, "pop", err)
+
+	mdi.AssertExpectations(t)
+
+}
+
+func TestSubmitNewTransactionEventFail(t *testing.T) {
+
+	mdi := &databasemocks.Plugin{}
+	txHelper := NewTransactionHelper(mdi)
+	ctx := context.Background()
+
+	mdi.On("InsertTransaction", ctx, mock.Anything).Return(nil)
+	mdi.On("InsertEvent", ctx, mock.Anything).Return(fmt.Errorf("pop"))
+
+	_, err := txHelper.SubmitNewTransaction(ctx, "ns1", fftypes.TransactionTypeBatchPin)
+	assert.Regexp(t, "pop", err)
+
+	mdi.AssertExpectations(t)
+
+}
+
+func TestPersistTransactionNew(t *testing.T) {
+
+	mdi := &databasemocks.Plugin{}
+	txHelper := NewTransactionHelper(mdi)
+	ctx := context.Background()
+
+	txid := fftypes.NewUUID()
+	mdi.On("GetTransactionByID", ctx, txid).Return(nil, nil)
+	mdi.On("InsertTransaction", ctx, mock.MatchedBy(func(transaction *fftypes.Transaction) bool {
+		assert.Equal(t, txid, transaction.ID)
+		assert.Equal(t, "ns1", transaction.Namespace)
+		assert.Equal(t, fftypes.TransactionTypeBatchPin, transaction.Type)
+		assert.Equal(t, fftypes.FFStringArray{"0x222222"}, transaction.BlockchainIDs)
+		return true
+	})).Return(nil)
+
+	valid, err := txHelper.PersistTransaction(ctx, "ns1", txid, fftypes.TransactionTypeBatchPin, "0x222222")
+	assert.NoError(t, err)
+	assert.True(t, valid)
+
+	mdi.AssertExpectations(t)
+
+}
+
+func TestPersistTransactionNewInserTFail(t *testing.T) {
+
+	mdi := &databasemocks.Plugin{}
+	txHelper := NewTransactionHelper(mdi)
+	ctx := context.Background()
+
+	txid := fftypes.NewUUID()
+	mdi.On("GetTransactionByID", ctx, txid).Return(nil, nil)
+	mdi.On("InsertTransaction", ctx, mock.Anything).Return(fmt.Errorf("pop"))
+
+	valid, err := txHelper.PersistTransaction(ctx, "ns1", txid, fftypes.TransactionTypeBatchPin, "0x222222")
+	assert.Regexp(t, "pop", err)
+	assert.False(t, valid)
+
+	mdi.AssertExpectations(t)
+
+}
+
+func TestPersistTransactionExistingAddBlockchainID(t *testing.T) {
+
+	mdi := &databasemocks.Plugin{}
+	txHelper := NewTransactionHelper(mdi)
+	ctx := context.Background()
+
+	txid := fftypes.NewUUID()
+	mdi.On("GetTransactionByID", ctx, txid).Return(&fftypes.Transaction{
+		ID:            txid,
+		Namespace:     "ns1",
+		Type:          fftypes.TransactionTypeBatchPin,
+		Created:       fftypes.Now(),
+		BlockchainIDs: fftypes.FFStringArray{"0x111111"},
+	}, nil)
+	mdi.On("UpdateTransaction", ctx, txid, mock.Anything).Return(nil)
+
+	valid, err := txHelper.PersistTransaction(ctx, "ns1", txid, fftypes.TransactionTypeBatchPin, "0x222222")
+	assert.NoError(t, err)
+	assert.True(t, valid)
+
+	mdi.AssertExpectations(t)
+
+}
+
+func TestPersistTransactionExistingUpdateFail(t *testing.T) {
+
+	mdi := &databasemocks.Plugin{}
+	txHelper := NewTransactionHelper(mdi)
+	ctx := context.Background()
+
+	txid := fftypes.NewUUID()
+	mdi.On("GetTransactionByID", ctx, txid).Return(&fftypes.Transaction{
+		ID:            txid,
+		Namespace:     "ns1",
+		Type:          fftypes.TransactionTypeBatchPin,
+		Created:       fftypes.Now(),
+		BlockchainIDs: fftypes.FFStringArray{"0x111111"},
+	}, nil)
+	mdi.On("UpdateTransaction", ctx, txid, mock.Anything).Return(fmt.Errorf("pop"))
+
+	valid, err := txHelper.PersistTransaction(ctx, "ns1", txid, fftypes.TransactionTypeBatchPin, "0x222222")
+	assert.Regexp(t, "pop", err)
+	assert.False(t, valid)
+
+	mdi.AssertExpectations(t)
+
+}
+
+func TestPersistTransactionExistingNoChange(t *testing.T) {
+
+	mdi := &databasemocks.Plugin{}
+	txHelper := NewTransactionHelper(mdi)
+	ctx := context.Background()
+
+	txid := fftypes.NewUUID()
+	mdi.On("GetTransactionByID", ctx, txid).Return(&fftypes.Transaction{
+		ID:            txid,
+		Namespace:     "ns1",
+		Type:          fftypes.TransactionTypeBatchPin,
+		Created:       fftypes.Now(),
+		BlockchainIDs: fftypes.FFStringArray{"0x111111"},
+	}, nil)
+
+	valid, err := txHelper.PersistTransaction(ctx, "ns1", txid, fftypes.TransactionTypeBatchPin, "0x111111")
+	assert.NoError(t, err)
+	assert.True(t, valid)
+
+	mdi.AssertExpectations(t)
+
+}
+
+func TestPersistTransactionExistingNoBlockchainID(t *testing.T) {
+
+	mdi := &databasemocks.Plugin{}
+	txHelper := NewTransactionHelper(mdi)
+	ctx := context.Background()
+
+	txid := fftypes.NewUUID()
+	mdi.On("GetTransactionByID", ctx, txid).Return(&fftypes.Transaction{
+		ID:            txid,
+		Namespace:     "ns1",
+		Type:          fftypes.TransactionTypeBatchPin,
+		Created:       fftypes.Now(),
+		BlockchainIDs: fftypes.FFStringArray{"0x111111"},
+	}, nil)
+
+	valid, err := txHelper.PersistTransaction(ctx, "ns1", txid, fftypes.TransactionTypeBatchPin, "")
+	assert.NoError(t, err)
+	assert.True(t, valid)
+
+	mdi.AssertExpectations(t)
+
+}
+
+func TestPersistTransactionExistingLookupFail(t *testing.T) {
+
+	mdi := &databasemocks.Plugin{}
+	txHelper := NewTransactionHelper(mdi)
+	ctx := context.Background()
+
+	txid := fftypes.NewUUID()
+	mdi.On("GetTransactionByID", ctx, txid).Return(nil, fmt.Errorf("pop"))
+
+	valid, err := txHelper.PersistTransaction(ctx, "ns1", txid, fftypes.TransactionTypeBatchPin, "")
+	assert.Regexp(t, "pop", err)
+	assert.False(t, valid)
+
+	mdi.AssertExpectations(t)
+
+}
+
+func TestPersistTransactionExistingMismatchNS(t *testing.T) {
+
+	mdi := &databasemocks.Plugin{}
+	txHelper := NewTransactionHelper(mdi)
+	ctx := context.Background()
+
+	txid := fftypes.NewUUID()
+	mdi.On("GetTransactionByID", ctx, txid).Return(&fftypes.Transaction{
+		ID:            txid,
+		Namespace:     "ns2",
+		Type:          fftypes.TransactionTypeBatchPin,
+		Created:       fftypes.Now(),
+		BlockchainIDs: fftypes.FFStringArray{"0x111111"},
+	}, nil)
+
+	valid, err := txHelper.PersistTransaction(ctx, "ns1", txid, fftypes.TransactionTypeBatchPin, "")
+	assert.NoError(t, err)
+	assert.False(t, valid)
+
+	mdi.AssertExpectations(t)
+
+}
+
+func TestPersistTransactionExistingMismatchType(t *testing.T) {
+
+	mdi := &databasemocks.Plugin{}
+	txHelper := NewTransactionHelper(mdi)
+	ctx := context.Background()
+
+	txid := fftypes.NewUUID()
+	mdi.On("GetTransactionByID", ctx, txid).Return(&fftypes.Transaction{
+		ID:            txid,
+		Namespace:     "ns1",
+		Type:          fftypes.TransactionTypeContractInvoke,
+		Created:       fftypes.Now(),
+		BlockchainIDs: fftypes.FFStringArray{"0x111111"},
+	}, nil)
+
+	valid, err := txHelper.PersistTransaction(ctx, "ns1", txid, fftypes.TransactionTypeBatchPin, "")
+	assert.NoError(t, err)
+	assert.False(t, valid)
+
+	mdi.AssertExpectations(t)
+
+}

--- a/mocks/databasemocks/plugin.go
+++ b/mocks/databasemocks/plugin.go
@@ -2185,6 +2185,20 @@ func (_m *Plugin) InsertOperation(ctx context.Context, operation *fftypes.Operat
 	return r0
 }
 
+// InsertTransaction provides a mock function with given fields: ctx, data
+func (_m *Plugin) InsertTransaction(ctx context.Context, data *fftypes.Transaction) error {
+	ret := _m.Called(ctx, data)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Transaction) error); ok {
+		r0 = rf(ctx, data)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Name provides a mock function with given fields:
 func (_m *Plugin) Name() string {
 	ret := _m.Called()
@@ -2724,20 +2738,6 @@ func (_m *Plugin) UpsertTokenTransfer(ctx context.Context, transfer *fftypes.Tok
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.TokenTransfer) error); ok {
 		r0 = rf(ctx, transfer)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// UpsertTransaction provides a mock function with given fields: ctx, data
-func (_m *Plugin) UpsertTransaction(ctx context.Context, data *fftypes.Transaction) error {
-	ret := _m.Called(ctx, data)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Transaction) error); ok {
-		r0 = rf(ctx, data)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/mocks/txcommonmocks/helper.go
+++ b/mocks/txcommonmocks/helper.go
@@ -14,20 +14,57 @@ type Helper struct {
 	mock.Mock
 }
 
-// PersistTransaction provides a mock function with given fields: ctx, tx
-func (_m *Helper) PersistTransaction(ctx context.Context, tx *fftypes.Transaction) (bool, error) {
-	ret := _m.Called(ctx, tx)
+// AddBlockchainTX provides a mock function with given fields: ctx, id, blockchainTXID
+func (_m *Helper) AddBlockchainTX(ctx context.Context, id *fftypes.UUID, blockchainTXID string) error {
+	ret := _m.Called(ctx, id, blockchainTXID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.UUID, string) error); ok {
+		r0 = rf(ctx, id, blockchainTXID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// PersistTransaction provides a mock function with given fields: ctx, ns, id, txType, blockchainTXID
+func (_m *Helper) PersistTransaction(ctx context.Context, ns string, id *fftypes.UUID, txType fftypes.FFEnum, blockchainTXID string) (bool, error) {
+	ret := _m.Called(ctx, ns, id, txType, blockchainTXID)
 
 	var r0 bool
-	if rf, ok := ret.Get(0).(func(context.Context, *fftypes.Transaction) bool); ok {
-		r0 = rf(ctx, tx)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *fftypes.UUID, fftypes.FFEnum, string) bool); ok {
+		r0 = rf(ctx, ns, id, txType, blockchainTXID)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *fftypes.Transaction) error); ok {
-		r1 = rf(ctx, tx)
+	if rf, ok := ret.Get(1).(func(context.Context, string, *fftypes.UUID, fftypes.FFEnum, string) error); ok {
+		r1 = rf(ctx, ns, id, txType, blockchainTXID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// SubmitNewTransaction provides a mock function with given fields: ctx, ns, txType
+func (_m *Helper) SubmitNewTransaction(ctx context.Context, ns string, txType fftypes.FFEnum) (*fftypes.UUID, error) {
+	ret := _m.Called(ctx, ns, txType)
+
+	var r0 *fftypes.UUID
+	if rf, ok := ret.Get(0).(func(context.Context, string, fftypes.FFEnum) *fftypes.UUID); ok {
+		r0 = rf(ctx, ns, txType)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*fftypes.UUID)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, fftypes.FFEnum) error); ok {
+		r1 = rf(ctx, ns, txType)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/database/plugin.go
+++ b/pkg/database/plugin.go
@@ -132,8 +132,8 @@ type iBatchCollection interface {
 }
 
 type iTransactionCollection interface {
-	// UpsertTransaction - Upsert a transaction
-	UpsertTransaction(ctx context.Context, data *fftypes.Transaction) (err error)
+	// InsertTransaction - Insert a new transaction
+	InsertTransaction(ctx context.Context, data *fftypes.Transaction) (err error)
 
 	// UpdateTransaction - Update transaction
 	UpdateTransaction(ctx context.Context, id *fftypes.UUID, update Update) (err error)

--- a/pkg/fftypes/event.go
+++ b/pkg/fftypes/event.go
@@ -20,6 +20,8 @@ package fftypes
 type EventType = FFEnum
 
 var (
+	// EventTypeTransactionSubmitted occurs only on the node that initiates a tranaction, when the transaction is submitted
+	EventTypeTransactionSubmitted EventType = ffEnum("eventtype", "transaction_submitted")
 	// EventTypeMessageConfirmed is the most important event type in the system. This means a message and all of its data
 	// is available for processing by an application. Most applications only need to listen to this event type
 	EventTypeMessageConfirmed EventType = ffEnum("eventtype", "message_confirmed")

--- a/pkg/fftypes/stringarray.go
+++ b/pkg/fftypes/stringarray.go
@@ -115,24 +115,30 @@ func (sa FFStringArray) Validate(ctx context.Context, fieldName string, isName b
 	return nil
 }
 
-func (sa FFStringArray) AppendLowerUnique(s string) FFStringArray {
+func (sa FFStringArray) appendLowerIfUnique(s string) FFStringArray {
+	if s == "" {
+		return sa
+	}
 	for _, existing := range sa {
-		if s == "" || strings.EqualFold(s, existing) {
+		if strings.EqualFold(s, existing) {
 			return sa
 		}
 	}
 	return append(sa, strings.ToLower(s))
 }
 
-// MergeLower returns a new array with a unique set of sorted lower case strings
-func (sa FFStringArray) MergeLower(osa FFStringArray) FFStringArray {
-	res := make(FFStringArray, 0, len(sa)+len(osa))
-	for _, s := range sa {
-		res = res.AppendLowerUnique(s)
+// AddToSortedSet determines if the new string is already in the set of strings (case insensitive),
+// and if not it adds it to the list (lower case) and returns a new slice of alphabetically sorted
+// strings reference and true.
+// If no change is made, the original reference is returned and false.
+func (sa FFStringArray) AddToSortedSet(newValues ...string) (res FFStringArray, changed bool) {
+	res = sa
+	for _, s := range newValues {
+		res = res.appendLowerIfUnique(s)
 	}
-	for _, s := range osa {
-		res = res.AppendLowerUnique(s)
+	if len(res) != len(sa) {
+		sort.Strings(res)
+		return res, true
 	}
-	sort.Strings(res)
-	return res
+	return sa, false
 }

--- a/pkg/fftypes/stringarray_test.go
+++ b/pkg/fftypes/stringarray_test.go
@@ -111,8 +111,18 @@ func TestFFStringArrayScanValue(t *testing.T) {
 
 func TestFFStringArrayMergeFold(t *testing.T) {
 
-	sa := NewFFStringArray("name2", "NAME1")
-	assert.Equal(t, FFStringArray{"name1", "name2", "name3"}, sa.MergeLower(FFStringArray{"name3"}))
-	assert.Equal(t, FFStringArray{"name1", "name2", "name3", "name4"}, sa.MergeLower(FFStringArray{"NAME4", "NAME3", "name1", "name2"}))
+	sa := NewFFStringArray("name2", "name1")
+
+	nsa, changed := sa.AddToSortedSet("Name3")
+	assert.True(t, changed)
+	assert.Equal(t, FFStringArray{"name1", "name2", "name3"}, nsa)
+
+	nsa, changed = sa.AddToSortedSet("name1", "")
+	assert.False(t, changed)
+	assert.Equal(t, sa, nsa)
+
+	nsa, changed = sa.AddToSortedSet("NAME4", "NAME3", "name1", "name2")
+	assert.True(t, changed)
+	assert.Equal(t, FFStringArray{"name1", "name2", "name3", "name4"}, nsa)
 
 }


### PR DESCRIPTION
Fixes https://github.com/hyperledger/firefly/issues/450

I removed `UpsertTransaction` from DB layer, as the only thing that can now change is the `blockchainIds` array, and that needs merging.

So I moved that logic up to `txcommon.Helper`, in a way that means:
- Creating a new Transaction is a single `INSERT`
- Adding a blockchain TXID to an existing Transaction is one `SELECT` followed by `INSERT`
- Re-adding a blockchain TXID that's already persisted for a 2nd time is a single `SELECT`