### PR TITLE
Prevent inserting token transfers with invalid blockchain event refs

### DIFF
--- a/internal/events/blockchain_event.go
+++ b/internal/events/blockchain_event.go
@@ -72,11 +72,14 @@ func (em *eventManager) getChainListenerByProtocolIDCached(ctx context.Context, 
 }
 
 func (em *eventManager) maybePersistBlockchainEvent(ctx context.Context, chainEvent *core.BlockchainEvent, listener *core.ContractListener) error {
-	inserted, err := em.txHelper.InsertNewBlockchainEvents(ctx, []*core.BlockchainEvent{chainEvent})
+	existing, err := em.txHelper.InsertOrGetBlockchainEvent(ctx, chainEvent)
 	if err != nil {
 		return err
 	}
-	if len(inserted) < 1 {
+	if existing != nil {
+		log.L(ctx).Debugf("Ignoring duplicate blockchain event %s", chainEvent.ProtocolID)
+		// Return the ID of the existing event
+		chainEvent.ID = existing.ID
 		return nil
 	}
 	topic := em.getTopicForChainListener(listener)

--- a/internal/events/blockchain_event_test.go
+++ b/internal/events/blockchain_event_test.go
@@ -164,12 +164,14 @@ func TestPersistBlockchainEventDuplicate(t *testing.T) {
 		},
 		Listener: fftypes.NewUUID(),
 	}
+	existingID := fftypes.NewUUID()
 
-	em.mth.On("InsertNewBlockchainEvents", mock.Anything, []*core.BlockchainEvent{ev}).
-		Return([]*core.BlockchainEvent{ /* duplicate, so empty insert array */ }, nil)
+	em.mth.On("InsertOrGetBlockchainEvent", mock.Anything, ev).
+		Return(&core.BlockchainEvent{ID: existingID}, nil)
 
 	err := em.maybePersistBlockchainEvent(em.ctx, ev, nil)
 	assert.NoError(t, err)
+	assert.Equal(t, existingID, ev.ID)
 
 }
 

--- a/internal/events/token_pool_created_test.go
+++ b/internal/events/token_pool_created_test.go
@@ -122,9 +122,9 @@ func TestTokenPoolCreatedConfirm(t *testing.T) {
 
 	em.mam.On("GetTokenPoolByLocator", em.ctx, "erc1155", "123").Return(nil, fmt.Errorf("pop")).Once()
 	em.mam.On("GetTokenPoolByLocator", em.ctx, "erc1155", "123").Return(storedPool, nil).Once()
-	em.mth.On("InsertNewBlockchainEvents", em.ctx, mock.MatchedBy(func(events []*core.BlockchainEvent) bool {
-		return len(events) == 1 && events[0].Name == chainPool.Event.Name
-	})).Return([]*core.BlockchainEvent{{ID: fftypes.NewUUID()}}, nil)
+	em.mth.On("InsertOrGetBlockchainEvent", em.ctx, mock.MatchedBy(func(e *core.BlockchainEvent) bool {
+		return e.Name == chainPool.Event.Name
+	})).Return(nil, nil)
 	em.mdi.On("InsertEvent", em.ctx, mock.MatchedBy(func(e *core.Event) bool {
 		return e.Type == core.EventTypeBlockchainEventReceived
 	})).Return(nil).Once()
@@ -246,7 +246,9 @@ func TestConfirmPoolBlockchainEventFail(t *testing.T) {
 		ProtocolID:     "tx1",
 	}
 
-	em.mth.On("InsertNewBlockchainEvents", em.ctx, mock.Anything).Return(nil, fmt.Errorf("pop"))
+	em.mth.On("InsertOrGetBlockchainEvent", em.ctx, mock.MatchedBy(func(e *core.BlockchainEvent) bool {
+		return e.Name == event.Name
+	})).Return(nil, fmt.Errorf("pop"))
 
 	err := em.confirmPool(em.ctx, storedPool, event)
 	assert.EqualError(t, err, "pop")
@@ -274,9 +276,9 @@ func TestConfirmPoolTxFail(t *testing.T) {
 		ProtocolID:     "tx1",
 	}
 
-	em.mth.On("InsertNewBlockchainEvents", em.ctx, mock.MatchedBy(func(events []*core.BlockchainEvent) bool {
-		return len(events) == 1 && events[0].Name == event.Name
-	})).Return([]*core.BlockchainEvent{{ID: fftypes.NewUUID()}}, nil)
+	em.mth.On("InsertOrGetBlockchainEvent", em.ctx, mock.MatchedBy(func(e *core.BlockchainEvent) bool {
+		return e.Name == event.Name
+	})).Return(nil, nil)
 	em.mdi.On("InsertEvent", em.ctx, mock.MatchedBy(func(e *core.Event) bool {
 		return e.Type == core.EventTypeBlockchainEventReceived
 	})).Return(nil)
@@ -308,9 +310,9 @@ func TestConfirmPoolUpsertFail(t *testing.T) {
 		ProtocolID:     "tx1",
 	}
 
-	em.mth.On("InsertNewBlockchainEvents", em.ctx, mock.MatchedBy(func(events []*core.BlockchainEvent) bool {
-		return len(events) == 1 && events[0].Name == event.Name
-	})).Return([]*core.BlockchainEvent{{ID: fftypes.NewUUID()}}, nil)
+	em.mth.On("InsertOrGetBlockchainEvent", em.ctx, mock.MatchedBy(func(e *core.BlockchainEvent) bool {
+		return e.Name == event.Name
+	})).Return(nil, nil)
 	em.mdi.On("InsertEvent", em.ctx, mock.MatchedBy(func(e *core.Event) bool {
 		return e.Type == core.EventTypeBlockchainEventReceived
 	})).Return(nil)

--- a/internal/events/tokens_approved_test.go
+++ b/internal/events/tokens_approved_test.go
@@ -73,9 +73,9 @@ func TestTokensApprovedSucceedWithRetries(t *testing.T) {
 	em.mam.On("GetTokenPoolByID", em.ctx, pool.ID).Return(pool, nil).Times(3)
 	em.mdi.On("GetTokenApprovalByProtocolID", em.ctx, "ns1", pool.ID, approval.ProtocolID).Return(nil, fmt.Errorf("pop")).Once()
 	em.mdi.On("GetTokenApprovalByProtocolID", em.ctx, "ns1", pool.ID, approval.ProtocolID).Return(nil, nil).Times(3)
-	em.mth.On("InsertNewBlockchainEvents", em.ctx, mock.MatchedBy(func(events []*core.BlockchainEvent) bool {
-		return len(events) == 1 && events[0].Name == approval.Event.Name && events[0].Namespace == approval.Namespace
-	})).Return([]*core.BlockchainEvent{{ID: fftypes.NewUUID()}}, nil)
+	em.mth.On("InsertOrGetBlockchainEvent", em.ctx, mock.MatchedBy(func(e *core.BlockchainEvent) bool {
+		return e.Namespace == pool.Namespace && e.Name == approval.Event.Name
+	})).Return(nil, nil).Times(3)
 	em.mdi.On("InsertEvent", em.ctx, mock.MatchedBy(func(ev *core.Event) bool {
 		return ev.Type == core.EventTypeBlockchainEventReceived && ev.Namespace == pool.Namespace
 	})).Return(nil).Times(3)
@@ -258,9 +258,9 @@ func TestApprovedWithTransactionRegenerateLocalID(t *testing.T) {
 	em.mth.On("FindOperationInTransaction", em.ctx, approval.TX.ID, core.OpTypeTokenApproval).Return(op, nil)
 	em.mth.On("PersistTransaction", mock.Anything, approval.TX.ID, core.TransactionTypeTokenApproval, "0xffffeeee").Return(true, nil)
 	em.mdi.On("GetTokenApprovalByID", em.ctx, "ns1", localID).Return(&core.TokenApproval{}, nil)
-	em.mth.On("InsertNewBlockchainEvents", em.ctx, mock.MatchedBy(func(events []*core.BlockchainEvent) bool {
-		return len(events) == 1 && events[0].Namespace == pool.Namespace && events[0].Name == approval.Event.Name
-	})).Return([]*core.BlockchainEvent{{ID: fftypes.NewUUID()}}, nil)
+	em.mth.On("InsertOrGetBlockchainEvent", em.ctx, mock.MatchedBy(func(e *core.BlockchainEvent) bool {
+		return e.Namespace == pool.Namespace && e.Name == approval.Event.Name
+	})).Return(nil, nil)
 	em.mdi.On("InsertEvent", em.ctx, mock.MatchedBy(func(ev *core.Event) bool {
 		return ev.Type == core.EventTypeBlockchainEventReceived && ev.Namespace == pool.Namespace
 	})).Return(nil)
@@ -299,8 +299,8 @@ func TestApprovedBlockchainEventFail(t *testing.T) {
 	em.mth.On("FindOperationInTransaction", em.ctx, approval.TX.ID, core.OpTypeTokenApproval).Return(op, nil)
 	em.mth.On("PersistTransaction", mock.Anything, approval.TX.ID, core.TransactionTypeTokenApproval, "0xffffeeee").Return(true, nil)
 	em.mdi.On("GetTokenApprovalByID", em.ctx, "ns1", localID).Return(&core.TokenApproval{}, nil)
-	em.mth.On("InsertNewBlockchainEvents", em.ctx, mock.MatchedBy(func(events []*core.BlockchainEvent) bool {
-		return len(events) == 1 && events[0].Namespace == pool.Namespace && events[0].Name == approval.Event.Name
+	em.mth.On("InsertOrGetBlockchainEvent", em.ctx, mock.MatchedBy(func(e *core.BlockchainEvent) bool {
+		return e.Namespace == pool.Namespace && e.Name == approval.Event.Name
 	})).Return(nil, fmt.Errorf("pop"))
 
 	valid, err := em.persistTokenApproval(em.ctx, approval)
@@ -341,9 +341,9 @@ func TestTokensApprovedWithMessageReceived(t *testing.T) {
 	em.mdi.On("GetTokenApprovalByProtocolID", em.ctx, "ns1", pool.ID, "123").Return(nil, nil).Times(2)
 	em.mam.On("GetTokenPoolByLocator", em.ctx, "erc1155", "F1").Return(pool, nil).Once()
 	em.mam.On("GetTokenPoolByID", em.ctx, pool.ID).Return(pool, nil).Once()
-	em.mth.On("InsertNewBlockchainEvents", em.ctx, mock.MatchedBy(func(events []*core.BlockchainEvent) bool {
-		return len(events) == 1 && events[0].Namespace == pool.Namespace && events[0].Name == approval.Event.Name
-	})).Return([]*core.BlockchainEvent{{ID: fftypes.NewUUID()}}, nil).Times(2)
+	em.mth.On("InsertOrGetBlockchainEvent", em.ctx, mock.MatchedBy(func(e *core.BlockchainEvent) bool {
+		return e.Namespace == pool.Namespace && e.Name == approval.Event.Name
+	})).Return(nil, nil).Times(2)
 	em.mdi.On("InsertEvent", em.ctx, mock.MatchedBy(func(ev *core.Event) bool {
 		return ev.Type == core.EventTypeBlockchainEventReceived && ev.Namespace == pool.Namespace
 	})).Return(nil).Times(2)
@@ -394,9 +394,9 @@ func TestTokensApprovedWithMessageSend(t *testing.T) {
 	em.mdi.On("GetTokenApprovalByProtocolID", em.ctx, "ns1", pool.ID, "123").Return(nil, nil).Times(2)
 	em.mam.On("GetTokenPoolByLocator", em.ctx, "erc1155", "F1").Return(pool, nil).Once()
 	em.mam.On("GetTokenPoolByID", em.ctx, pool.ID).Return(pool, nil).Once()
-	em.mth.On("InsertNewBlockchainEvents", em.ctx, mock.MatchedBy(func(events []*core.BlockchainEvent) bool {
-		return len(events) == 1 && events[0].Namespace == pool.Namespace && events[0].Name == approval.Event.Name
-	})).Return([]*core.BlockchainEvent{{ID: fftypes.NewUUID()}}, nil).Times(2)
+	em.mth.On("InsertOrGetBlockchainEvent", em.ctx, mock.MatchedBy(func(e *core.BlockchainEvent) bool {
+		return e.Namespace == pool.Namespace && e.Name == approval.Event.Name
+	})).Return(nil, nil).Times(2)
 	em.mdi.On("InsertEvent", em.ctx, mock.MatchedBy(func(ev *core.Event) bool {
 		return ev.Type == core.EventTypeBlockchainEventReceived && ev.Namespace == pool.Namespace
 	})).Return(nil).Times(2)

--- a/internal/events/tokens_transferred_test.go
+++ b/internal/events/tokens_transferred_test.go
@@ -72,9 +72,9 @@ func TestTokensTransferredSucceedWithRetries(t *testing.T) {
 	em.mam.On("GetTokenPoolByLocator", em.ctx, "erc1155", "F1").Return(nil, fmt.Errorf("pop")).Once()
 	em.mam.On("GetTokenPoolByLocator", em.ctx, "erc1155", "F1").Return(pool, nil).Once()
 	em.mam.On("GetTokenPoolByID", em.ctx, pool.ID).Return(pool, nil).Times(2)
-	em.mth.On("InsertNewBlockchainEvents", em.ctx, mock.MatchedBy(func(events []*core.BlockchainEvent) bool {
-		return len(events) == 1 && events[0].Namespace == pool.Namespace && events[0].Name == transfer.Event.Name
-	})).Return([]*core.BlockchainEvent{{ID: fftypes.NewUUID()}}, nil)
+	em.mth.On("InsertOrGetBlockchainEvent", em.ctx, mock.MatchedBy(func(e *core.BlockchainEvent) bool {
+		return e.Namespace == pool.Namespace && e.Name == transfer.Event.Name
+	})).Return(nil, nil).Times(3)
 	em.mdi.On("InsertEvent", em.ctx, mock.MatchedBy(func(ev *core.Event) bool {
 		return ev.Type == core.EventTypeBlockchainEventReceived && ev.Namespace == pool.Namespace
 	})).Return(nil).Times(3)
@@ -212,8 +212,8 @@ func TestPersistTransferBlockchainEventFail(t *testing.T) {
 	em.mth.On("FindOperationInTransaction", em.ctx, transfer.TX.ID, core.OpTypeTokenTransfer).Return(op, nil)
 	em.mth.On("PersistTransaction", mock.Anything, transfer.TX.ID, core.TransactionTypeTokenTransfer, "0xffffeeee").Return(true, nil)
 	em.mdi.On("GetTokenTransferByID", em.ctx, "ns1", localID).Return(nil, nil)
-	em.mth.On("InsertNewBlockchainEvents", em.ctx, mock.MatchedBy(func(events []*core.BlockchainEvent) bool {
-		return len(events) == 1 && events[0].Namespace == pool.Namespace && events[0].Name == transfer.Event.Name
+	em.mth.On("InsertOrGetBlockchainEvent", em.ctx, mock.MatchedBy(func(e *core.BlockchainEvent) bool {
+		return e.Namespace == pool.Namespace && e.Name == transfer.Event.Name
 	})).Return(nil, fmt.Errorf("pop"))
 
 	valid, err := em.persistTokenTransfer(em.ctx, transfer)
@@ -246,9 +246,9 @@ func TestTokensTransferredWithTransactionRegenerateLocalID(t *testing.T) {
 	em.mth.On("FindOperationInTransaction", em.ctx, transfer.TX.ID, core.OpTypeTokenTransfer).Return(op, nil)
 	em.mth.On("PersistTransaction", mock.Anything, transfer.TX.ID, core.TransactionTypeTokenTransfer, "0xffffeeee").Return(true, nil)
 	em.mdi.On("GetTokenTransferByID", em.ctx, "ns1", localID).Return(&core.TokenTransfer{}, nil)
-	em.mth.On("InsertNewBlockchainEvents", em.ctx, mock.MatchedBy(func(events []*core.BlockchainEvent) bool {
-		return len(events) == 1 && events[0].Namespace == pool.Namespace && events[0].Name == transfer.Event.Name
-	})).Return([]*core.BlockchainEvent{{ID: fftypes.NewUUID()}}, nil)
+	em.mth.On("InsertOrGetBlockchainEvent", em.ctx, mock.MatchedBy(func(e *core.BlockchainEvent) bool {
+		return e.Namespace == pool.Namespace && e.Name == transfer.Event.Name
+	})).Return(nil, nil)
 	em.mdi.On("InsertEvent", em.ctx, mock.MatchedBy(func(ev *core.Event) bool {
 		return ev.Type == core.EventTypeBlockchainEventReceived && ev.Namespace == pool.Namespace
 	})).Return(nil)
@@ -285,9 +285,9 @@ func TestTokensTransferredWithExistingTransfer(t *testing.T) {
 	}
 
 	em.mam.On("GetTokenPoolByLocator", em.ctx, "erc1155", "F1").Return(pool, nil)
-	em.mth.On("InsertNewBlockchainEvents", em.ctx, mock.MatchedBy(func(events []*core.BlockchainEvent) bool {
-		return len(events) == 1 && events[0].Namespace == pool.Namespace && events[0].Name == transfer.Event.Name
-	})).Return([]*core.BlockchainEvent{{ID: fftypes.NewUUID()}}, nil)
+	em.mth.On("InsertOrGetBlockchainEvent", em.ctx, mock.MatchedBy(func(e *core.BlockchainEvent) bool {
+		return e.Namespace == pool.Namespace && e.Name == transfer.Event.Name
+	})).Return(nil, nil)
 	em.mdi.On("InsertEvent", em.ctx, mock.MatchedBy(func(ev *core.Event) bool {
 		return ev.Type == core.EventTypeBlockchainEventReceived && ev.Namespace == pool.Namespace
 	})).Return(nil)
@@ -359,9 +359,9 @@ func TestTokensTransferredWithMessageReceived(t *testing.T) {
 
 	em.mam.On("GetTokenPoolByLocator", em.ctx, "erc1155", "F1").Return(pool, nil).Once()
 	em.mam.On("GetTokenPoolByID", em.ctx, pool.ID).Return(pool, nil).Once()
-	em.mth.On("InsertNewBlockchainEvents", em.ctx, mock.MatchedBy(func(events []*core.BlockchainEvent) bool {
-		return len(events) == 1 && events[0].Namespace == pool.Namespace && events[0].Name == transfer.Event.Name
-	})).Return([]*core.BlockchainEvent{{ID: fftypes.NewUUID()}}, nil).Times(2)
+	em.mth.On("InsertOrGetBlockchainEvent", em.ctx, mock.MatchedBy(func(e *core.BlockchainEvent) bool {
+		return e.Namespace == pool.Namespace && e.Name == transfer.Event.Name
+	})).Return(nil, nil).Times(2)
 	em.mdi.On("InsertEvent", em.ctx, mock.MatchedBy(func(ev *core.Event) bool {
 		return ev.Type == core.EventTypeBlockchainEventReceived && ev.Namespace == pool.Namespace
 	})).Return(nil).Times(2)
@@ -418,9 +418,9 @@ func TestTokensTransferredWithMessageSend(t *testing.T) {
 
 	em.mam.On("GetTokenPoolByLocator", em.ctx, "erc1155", "F1").Return(pool, nil).Once()
 	em.mam.On("GetTokenPoolByID", em.ctx, pool.ID).Return(pool, nil).Once()
-	em.mth.On("InsertNewBlockchainEvents", em.ctx, mock.MatchedBy(func(events []*core.BlockchainEvent) bool {
-		return len(events) == 1 && events[0].Namespace == pool.Namespace && events[0].Name == transfer.Event.Name
-	})).Return([]*core.BlockchainEvent{{ID: fftypes.NewUUID()}}, nil).Times(2)
+	em.mth.On("InsertOrGetBlockchainEvent", em.ctx, mock.MatchedBy(func(e *core.BlockchainEvent) bool {
+		return e.Namespace == pool.Namespace && e.Name == transfer.Event.Name
+	})).Return(nil, nil).Times(2)
 	em.mdi.On("InsertEvent", em.ctx, mock.MatchedBy(func(ev *core.Event) bool {
 		return ev.Type == core.EventTypeBlockchainEventReceived && ev.Namespace == pool.Namespace
 	})).Return(nil).Times(2)

--- a/mocks/txcommonmocks/helper.go
+++ b/mocks/txcommonmocks/helper.go
@@ -136,6 +136,32 @@ func (_m *Helper) InsertNewBlockchainEvents(ctx context.Context, events []*core.
 	return r0, r1
 }
 
+// InsertOrGetBlockchainEvent provides a mock function with given fields: ctx, event
+func (_m *Helper) InsertOrGetBlockchainEvent(ctx context.Context, event *core.BlockchainEvent) (*core.BlockchainEvent, error) {
+	ret := _m.Called(ctx, event)
+
+	var r0 *core.BlockchainEvent
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *core.BlockchainEvent) (*core.BlockchainEvent, error)); ok {
+		return rf(ctx, event)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *core.BlockchainEvent) *core.BlockchainEvent); ok {
+		r0 = rf(ctx, event)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*core.BlockchainEvent)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *core.BlockchainEvent) error); ok {
+		r1 = rf(ctx, event)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // PersistTransaction provides a mock function with given fields: ctx, id, txType, blockchainTXID
 func (_m *Helper) PersistTransaction(ctx context.Context, id *fftypes.UUID, txType fftypes.FFEnum, blockchainTXID string) (bool, error) {
 	ret := _m.Called(ctx, id, txType, blockchainTXID)


### PR DESCRIPTION
If an existing blockchain event is found, be sure to look up and use the existing ID when inserting token transfers/approvals.

Port of https://github.com/hyperledger/firefly/pull/1386