### PR TITLE
Do not expect to retrieve local org during definition handling

### DIFF
--- a/internal/definitions/handler_contracts.go
+++ b/internal/definitions/handler_contracts.go
@@ -161,11 +161,11 @@ func (dh *definitionHandler) handleFFIBroadcast(ctx context.Context, state *core
 		return HandlerResult{Action: core.ActionReject}, i18n.NewError(ctx, coremsgs.MsgDefRejectedBadPayload, "contract interface", msg.Header.ID)
 	}
 
-	org, err := dh.identity.GetRootOrg(ctx)
+	org, err := dh.identity.GetRootOrgDID(ctx)
 	if err != nil {
 		return HandlerResult{Action: core.ActionRetry}, err
 	}
-	isAuthor := org.DID == msg.Header.Author
+	isAuthor := org == msg.Header.Author
 
 	ffi.Message = msg.Header.ID
 	ffi.Name = ffi.NetworkName
@@ -198,11 +198,11 @@ func (dh *definitionHandler) handleContractAPIBroadcast(ctx context.Context, sta
 		return HandlerResult{Action: core.ActionReject}, i18n.NewError(ctx, coremsgs.MsgDefRejectedBadPayload, "contract API", msg.Header.ID)
 	}
 
-	org, err := dh.identity.GetRootOrg(ctx)
+	org, err := dh.identity.GetRootOrgDID(ctx)
 	if err != nil {
 		return HandlerResult{Action: core.ActionRetry}, err
 	}
-	isAuthor := org.DID == msg.Header.Author
+	isAuthor := org == msg.Header.Author
 
 	api.Message = msg.Header.ID
 	api.Name = api.NetworkName

--- a/internal/definitions/handler_contracts_test.go
+++ b/internal/definitions/handler_contracts_test.go
@@ -118,11 +118,7 @@ func TestHandleFFIBroadcastOk(t *testing.T) {
 	dh.mdi.On("UpsertFFIError", mock.Anything, mock.Anything).Return(nil)
 	dh.mdi.On("InsertEvent", mock.Anything, mock.Anything).Return(nil)
 	dh.mcm.On("ResolveFFI", mock.Anything, mock.Anything).Return(nil)
-	dh.mim.On("GetRootOrg", context.Background()).Return(&core.Identity{
-		IdentityBase: core.IdentityBase{
-			DID: "firefly:org1",
-		},
-	}, nil)
+	dh.mim.On("GetRootOrgDID", context.Background()).Return("firefly:org1", nil)
 
 	action, err := dh.HandleDefinitionBroadcast(context.Background(), &bs.BatchState, &core.Message{
 		Header: core.MessageHeader{
@@ -154,11 +150,7 @@ func TestHandleFFIBroadcastUpdate(t *testing.T) {
 	dh.mdi.On("InsertOrGetFFI", mock.Anything, mock.Anything).Return(existing, nil)
 	dh.mdi.On("InsertEvent", mock.Anything, mock.Anything).Return(nil)
 	dh.mcm.On("ResolveFFI", mock.Anything, mock.Anything).Return(nil)
-	dh.mim.On("GetRootOrg", context.Background()).Return(&core.Identity{
-		IdentityBase: core.IdentityBase{
-			DID: "firefly:org1",
-		},
-	}, nil)
+	dh.mim.On("GetRootOrgDID", context.Background()).Return("firefly:org1", nil)
 
 	action, err := dh.HandleDefinitionBroadcast(context.Background(), &bs.BatchState, &core.Message{
 		Header: core.MessageHeader{
@@ -198,11 +190,7 @@ func TestHandleFFIBroadcastNameExists(t *testing.T) {
 	dh.mdi.On("UpsertFFIError", mock.Anything, mock.Anything).Return(nil)
 	dh.mdi.On("InsertEvent", mock.Anything, mock.Anything).Return(nil)
 	dh.mcm.On("ResolveFFI", mock.Anything, mock.Anything).Return(nil)
-	dh.mim.On("GetRootOrg", context.Background()).Return(&core.Identity{
-		IdentityBase: core.IdentityBase{
-			DID: "firefly:org1",
-		},
-	}, nil)
+	dh.mim.On("GetRootOrgDID", context.Background()).Return("firefly:org1", nil)
 
 	action, err := dh.HandleDefinitionBroadcast(context.Background(), &bs.BatchState, &core.Message{
 		Header: core.MessageHeader{
@@ -381,7 +369,7 @@ func TestHandleFFIBroadcastOrgFail(t *testing.T) {
 		Value: fftypes.JSONAnyPtrBytes(b),
 	}
 
-	dh.mim.On("GetRootOrg", context.Background()).Return(nil, fmt.Errorf("pop"))
+	dh.mim.On("GetRootOrgDID", context.Background()).Return("", fmt.Errorf("pop"))
 
 	action, err := dh.HandleDefinitionBroadcast(context.Background(), &bs.BatchState, &core.Message{
 		Header: core.MessageHeader{
@@ -406,11 +394,7 @@ func TestHandleFFIBroadcastPersistFail(t *testing.T) {
 	}
 	dh.mdi.On("InsertOrGetFFI", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("pop"))
 	dh.mcm.On("ResolveFFI", mock.Anything, mock.Anything).Return(nil)
-	dh.mim.On("GetRootOrg", context.Background()).Return(&core.Identity{
-		IdentityBase: core.IdentityBase{
-			DID: "firefly:org1",
-		},
-	}, nil)
+	dh.mim.On("GetRootOrgDID", context.Background()).Return("firefly:org1", nil)
 
 	action, err := dh.HandleDefinitionBroadcast(context.Background(), &bs.BatchState, &core.Message{
 		Header: core.MessageHeader{
@@ -434,11 +418,7 @@ func TestHandleFFIBroadcastResolveFail(t *testing.T) {
 	}
 
 	dh.mcm.On("ResolveFFI", mock.Anything, mock.Anything).Return(fmt.Errorf("pop"))
-	dh.mim.On("GetRootOrg", context.Background()).Return(&core.Identity{
-		IdentityBase: core.IdentityBase{
-			DID: "firefly:org1",
-		},
-	}, nil)
+	dh.mim.On("GetRootOrgDID", context.Background()).Return("firefly:org1", nil)
 
 	action, err := dh.HandleDefinitionBroadcast(context.Background(), &bs.BatchState, &core.Message{
 		Header: core.MessageHeader{
@@ -464,11 +444,7 @@ func TestHandleContractAPIBroadcastOk(t *testing.T) {
 	dh.mdi.On("InsertOrGetContractAPI", mock.Anything, mock.Anything).Return(nil, nil)
 	dh.mdi.On("InsertEvent", mock.Anything, mock.Anything).Return(nil)
 	dh.mcm.On("ResolveContractAPI", context.Background(), "", mock.Anything).Return(nil)
-	dh.mim.On("GetRootOrg", context.Background()).Return(&core.Identity{
-		IdentityBase: core.IdentityBase{
-			DID: "firefly:org1",
-		},
-	}, nil)
+	dh.mim.On("GetRootOrgDID", context.Background()).Return("firefly:org1", nil)
 
 	action, err := dh.HandleDefinitionBroadcast(context.Background(), &bs.BatchState, &core.Message{
 		Header: core.MessageHeader{
@@ -510,11 +486,7 @@ func TestHandleContractAPIBroadcastPersistFail(t *testing.T) {
 
 	dh.mdi.On("InsertOrGetContractAPI", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("pop"))
 	dh.mcm.On("ResolveContractAPI", context.Background(), "", mock.Anything).Return(nil)
-	dh.mim.On("GetRootOrg", context.Background()).Return(&core.Identity{
-		IdentityBase: core.IdentityBase{
-			DID: "firefly:org1",
-		},
-	}, nil)
+	dh.mim.On("GetRootOrgDID", context.Background()).Return("firefly:org1", nil)
 
 	action, err := dh.HandleDefinitionBroadcast(context.Background(), &bs.BatchState, &core.Message{
 		Header: core.MessageHeader{
@@ -538,11 +510,7 @@ func TestHandleContractAPIBroadcastResolveFail(t *testing.T) {
 	}
 
 	dh.mcm.On("ResolveContractAPI", context.Background(), "", mock.Anything).Return(fmt.Errorf("pop"))
-	dh.mim.On("GetRootOrg", context.Background()).Return(&core.Identity{
-		IdentityBase: core.IdentityBase{
-			DID: "firefly:org1",
-		},
-	}, nil)
+	dh.mim.On("GetRootOrgDID", context.Background()).Return("firefly:org1", nil)
 
 	action, err := dh.HandleDefinitionBroadcast(context.Background(), &bs.BatchState, &core.Message{
 		Header: core.MessageHeader{
@@ -565,7 +533,7 @@ func TestHandleContractAPIBroadcastOrgFail(t *testing.T) {
 		Value: fftypes.JSONAnyPtrBytes(b),
 	}
 
-	dh.mim.On("GetRootOrg", context.Background()).Return(nil, fmt.Errorf("pop"))
+	dh.mim.On("GetRootOrgDID", context.Background()).Return("", fmt.Errorf("pop"))
 
 	action, err := dh.HandleDefinitionBroadcast(context.Background(), &bs.BatchState, &core.Message{
 		Header: core.MessageHeader{

--- a/internal/definitions/handler_tokenpool.go
+++ b/internal/definitions/handler_tokenpool.go
@@ -42,11 +42,11 @@ func (dh *definitionHandler) handleTokenPoolBroadcast(ctx context.Context, state
 		return HandlerResult{Action: core.ActionReject}, i18n.NewError(ctx, coremsgs.MsgInvalidConnectorName, pool.Connector, "token")
 	}
 
-	org, err := dh.identity.GetRootOrg(ctx)
+	org, err := dh.identity.GetRootOrgDID(ctx)
 	if err != nil {
 		return HandlerResult{Action: core.ActionRetry}, err
 	}
-	isAuthor := org.DID == msg.Header.Author
+	isAuthor := org == msg.Header.Author
 
 	pool.Message = msg.Header.ID
 	pool.Name = pool.NetworkName

--- a/internal/definitions/handler_tokenpool_test.go
+++ b/internal/definitions/handler_tokenpool_test.go
@@ -82,11 +82,7 @@ func TestHandleDefinitionBroadcastTokenPoolActivateOK(t *testing.T) {
 		return *p.ID == *pool.ID && p.Message == msg.Header.ID && p.Connector == "connector1"
 	})).Return(nil, nil)
 	dh.mam.On("ActivateTokenPool", context.Background(), mock.AnythingOfType("*core.TokenPool")).Return(nil)
-	dh.mim.On("GetRootOrg", context.Background()).Return(&core.Identity{
-		IdentityBase: core.IdentityBase{
-			DID: "firefly:org1",
-		},
-	}, nil)
+	dh.mim.On("GetRootOrgDID", context.Background()).Return("firefly:org1", nil)
 
 	action, err := dh.HandleDefinitionBroadcast(context.Background(), &bs.BatchState, msg, data, fftypes.NewUUID())
 	assert.Equal(t, HandlerResult{Action: core.ActionWait, CustomCorrelator: pool.ID}, action)
@@ -105,11 +101,7 @@ func TestHandleDefinitionBroadcastTokenPoolBadConnector(t *testing.T) {
 	msg, data, err := buildPoolDefinitionMessage(definition)
 	assert.NoError(t, err)
 
-	dh.mim.On("GetRootOrg", context.Background()).Return(&core.Identity{
-		IdentityBase: core.IdentityBase{
-			DID: "firefly:org1",
-		},
-	}, nil)
+	dh.mim.On("GetRootOrgDID", context.Background()).Return("firefly:org1", nil)
 
 	action, err := dh.HandleDefinitionBroadcast(context.Background(), &bs.BatchState, msg, data, fftypes.NewUUID())
 	assert.Equal(t, HandlerResult{Action: core.ActionReject, CustomCorrelator: pool.ID}, action)
@@ -137,11 +129,7 @@ func TestHandleDefinitionBroadcastTokenPoolNameExists(t *testing.T) {
 	dh.mdi.On("InsertOrGetTokenPool", context.Background(), mock.MatchedBy(func(p *core.TokenPool) bool {
 		return *p.ID == *pool.ID && p.Message == msg.Header.ID && p.Name == "name1-1"
 	})).Return(nil, nil)
-	dh.mim.On("GetRootOrg", context.Background()).Return(&core.Identity{
-		IdentityBase: core.IdentityBase{
-			DID: "firefly:org1",
-		},
-	}, nil)
+	dh.mim.On("GetRootOrgDID", context.Background()).Return("firefly:org1", nil)
 
 	action, err := dh.HandleDefinitionBroadcast(context.Background(), &bs.BatchState, msg, data, fftypes.NewUUID())
 	assert.Equal(t, HandlerResult{Action: core.ActionWait, CustomCorrelator: pool.ID}, action)
@@ -185,11 +173,7 @@ func TestHandleDefinitionBroadcastTokenPoolNetworkNameExists(t *testing.T) {
 	dh.mdi.On("InsertOrGetTokenPool", context.Background(), mock.MatchedBy(func(p *core.TokenPool) bool {
 		return *p.ID == *pool.ID && p.Message == msg.Header.ID
 	})).Return(existing, nil)
-	dh.mim.On("GetRootOrg", context.Background()).Return(&core.Identity{
-		IdentityBase: core.IdentityBase{
-			DID: "firefly:org1",
-		},
-	}, nil)
+	dh.mim.On("GetRootOrgDID", context.Background()).Return("firefly:org1", nil)
 
 	action, err := dh.HandleDefinitionBroadcast(context.Background(), &bs.BatchState, msg, data, fftypes.NewUUID())
 	assert.Equal(t, HandlerResult{Action: core.ActionReject, CustomCorrelator: pool.ID}, action)
@@ -215,11 +199,7 @@ func TestHandleDefinitionBroadcastTokenPoolExistingConfirmed(t *testing.T) {
 	dh.mdi.On("InsertOrGetTokenPool", context.Background(), mock.MatchedBy(func(p *core.TokenPool) bool {
 		return *p.ID == *pool.ID && p.Message == msg.Header.ID
 	})).Return(existing, nil)
-	dh.mim.On("GetRootOrg", context.Background()).Return(&core.Identity{
-		IdentityBase: core.IdentityBase{
-			DID: "firefly:org1",
-		},
-	}, nil)
+	dh.mim.On("GetRootOrgDID", context.Background()).Return("firefly:org1", nil)
 
 	action, err := dh.HandleDefinitionBroadcast(context.Background(), &bs.BatchState, msg, data, fftypes.NewUUID())
 	assert.Equal(t, HandlerResult{Action: core.ActionConfirm, CustomCorrelator: pool.ID}, action)
@@ -243,11 +223,7 @@ func TestHandleDefinitionBroadcastTokenPoolExistingWaiting(t *testing.T) {
 	dh.mdi.On("InsertOrGetTokenPool", context.Background(), mock.MatchedBy(func(p *core.TokenPool) bool {
 		return *p.ID == *pool.ID && p.Message == msg.Header.ID
 	})).Return(existing, nil)
-	dh.mim.On("GetRootOrg", context.Background()).Return(&core.Identity{
-		IdentityBase: core.IdentityBase{
-			DID: "firefly:org1",
-		},
-	}, nil)
+	dh.mim.On("GetRootOrgDID", context.Background()).Return("firefly:org1", nil)
 
 	action, err := dh.HandleDefinitionBroadcast(context.Background(), &bs.BatchState, msg, data, fftypes.NewUUID())
 	assert.Equal(t, HandlerResult{Action: core.ActionWait, CustomCorrelator: pool.ID}, action)
@@ -278,11 +254,7 @@ func TestHandleDefinitionBroadcastTokenPoolExistingPublish(t *testing.T) {
 		return *p.ID == *pool.ID && p.Message == msg.Header.ID
 	})).Return(existing, nil)
 	dh.mdi.On("UpsertTokenPool", context.Background(), &newPool, database.UpsertOptimizationExisting).Return(nil)
-	dh.mim.On("GetRootOrg", context.Background()).Return(&core.Identity{
-		IdentityBase: core.IdentityBase{
-			DID: "firefly:org1",
-		},
-	}, nil)
+	dh.mim.On("GetRootOrgDID", context.Background()).Return("firefly:org1", nil)
 
 	action, err := dh.HandleDefinitionBroadcast(context.Background(), &bs.BatchState, msg, data, fftypes.NewUUID())
 	assert.Equal(t, HandlerResult{Action: core.ActionConfirm, CustomCorrelator: pool.ID}, action)
@@ -313,11 +285,7 @@ func TestHandleDefinitionBroadcastTokenPoolExistingPublishUpsertFail(t *testing.
 		return *p.ID == *pool.ID && p.Message == msg.Header.ID
 	})).Return(existing, nil)
 	dh.mdi.On("UpsertTokenPool", context.Background(), &newPool, database.UpsertOptimizationExisting).Return(fmt.Errorf("pop"))
-	dh.mim.On("GetRootOrg", context.Background()).Return(&core.Identity{
-		IdentityBase: core.IdentityBase{
-			DID: "firefly:org1",
-		},
-	}, nil)
+	dh.mim.On("GetRootOrgDID", context.Background()).Return("firefly:org1", nil)
 
 	action, err := dh.HandleDefinitionBroadcast(context.Background(), &bs.BatchState, msg, data, fftypes.NewUUID())
 	assert.Equal(t, HandlerResult{Action: core.ActionRetry, CustomCorrelator: pool.ID}, action)
@@ -344,7 +312,7 @@ func TestHandleDefinitionBroadcastTokenPoolExistingPublishOrgFail(t *testing.T) 
 	newPool.Message = msg.Header.ID
 	newPool.State = core.TokenPoolStatePending
 
-	dh.mim.On("GetRootOrg", context.Background()).Return(nil, fmt.Errorf("pop"))
+	dh.mim.On("GetRootOrgDID", context.Background()).Return("", fmt.Errorf("pop"))
 
 	action, err := dh.HandleDefinitionBroadcast(context.Background(), &bs.BatchState, msg, data, fftypes.NewUUID())
 	assert.Equal(t, HandlerResult{Action: core.ActionRetry}, action)
@@ -374,11 +342,7 @@ func TestHandleDefinitionBroadcastTokenPoolExistingPublishOrgMismatch(t *testing
 	dh.mdi.On("InsertOrGetTokenPool", context.Background(), mock.MatchedBy(func(p *core.TokenPool) bool {
 		return *p.ID == *pool.ID && p.Message == msg.Header.ID
 	})).Return(existing, nil)
-	dh.mim.On("GetRootOrg", context.Background()).Return(&core.Identity{
-		IdentityBase: core.IdentityBase{
-			DID: "firefly:org2",
-		},
-	}, nil)
+	dh.mim.On("GetRootOrgDID", context.Background()).Return("firefly:org2", nil)
 
 	action, err := dh.HandleDefinitionBroadcast(context.Background(), &bs.BatchState, msg, data, fftypes.NewUUID())
 	assert.Equal(t, HandlerResult{Action: core.ActionReject, CustomCorrelator: pool.ID}, action)
@@ -396,11 +360,7 @@ func TestHandleDefinitionBroadcastTokenPoolFailUpsert(t *testing.T) {
 	dh.mdi.On("InsertOrGetTokenPool", context.Background(), mock.MatchedBy(func(p *core.TokenPool) bool {
 		return *p.ID == *pool.ID && p.Message == msg.Header.ID
 	})).Return(nil, fmt.Errorf("pop"))
-	dh.mim.On("GetRootOrg", context.Background()).Return(&core.Identity{
-		IdentityBase: core.IdentityBase{
-			DID: "firefly:org1",
-		},
-	}, nil)
+	dh.mim.On("GetRootOrgDID", context.Background()).Return("firefly:org1", nil)
 
 	action, err := dh.HandleDefinitionBroadcast(context.Background(), &bs.BatchState, msg, data, fftypes.NewUUID())
 	assert.Equal(t, HandlerResult{Action: core.ActionRetry}, action)
@@ -421,11 +381,7 @@ func TestHandleDefinitionBroadcastTokenPoolActivateFail(t *testing.T) {
 		return *p.ID == *pool.ID && p.Message == msg.Header.ID
 	})).Return(nil, nil)
 	dh.mam.On("ActivateTokenPool", context.Background(), mock.AnythingOfType("*core.TokenPool")).Return(fmt.Errorf("pop"))
-	dh.mim.On("GetRootOrg", context.Background()).Return(&core.Identity{
-		IdentityBase: core.IdentityBase{
-			DID: "firefly:org1",
-		},
-	}, nil)
+	dh.mim.On("GetRootOrgDID", context.Background()).Return("firefly:org1", nil)
 
 	action, err := dh.HandleDefinitionBroadcast(context.Background(), &bs.BatchState, msg, data, fftypes.NewUUID())
 	assert.Equal(t, HandlerResult{Action: core.ActionWait, CustomCorrelator: pool.ID}, action)

--- a/internal/identity/identitymanager_test.go
+++ b/internal/identity/identitymanager_test.go
@@ -1472,6 +1472,22 @@ func TestGetRootOrg(t *testing.T) {
 	mdi.AssertExpectations(t)
 }
 
+func TestGetRootOrgUnregistered(t *testing.T) {
+	ctx, im := newTestIdentityManager(t)
+	mmp := im.multiparty.(*multipartymocks.Manager)
+	mdi := im.database.(*databasemocks.Plugin)
+
+	mmp.On("RootOrg").Return(multiparty.RootOrg{Name: "org1"})
+	mdi.On("GetIdentityByDID", ctx, "ns1", "did:firefly:org/org1").Return(nil, nil)
+	mmp.On("GetNetworkVersion").Return(2)
+
+	_, err := im.GetRootOrg(ctx)
+	assert.Regexp(t, "FF10277", err)
+
+	mmp.AssertExpectations(t)
+	mdi.AssertExpectations(t)
+}
+
 func TestParseKeyNormalizationConfig(t *testing.T) {
 	assert.Equal(t, KeyNormalizationBlockchainPlugin, ParseKeyNormalizationConfig("blockchain_Plugin"))
 	assert.Equal(t, KeyNormalizationNone, ParseKeyNormalizationConfig("none"))

--- a/mocks/identitymanagermocks/manager.go
+++ b/mocks/identitymanagermocks/manager.go
@@ -189,6 +189,30 @@ func (_m *Manager) GetRootOrg(ctx context.Context) (*core.Identity, error) {
 	return r0, r1
 }
 
+// GetRootOrgDID provides a mock function with given fields: ctx
+func (_m *Manager) GetRootOrgDID(ctx context.Context) (string, error) {
+	ret := _m.Called(ctx)
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (string, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) string); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ResolveIdentitySigner provides a mock function with given fields: ctx, _a1
 func (_m *Manager) ResolveIdentitySigner(ctx context.Context, _a1 *core.Identity) (*core.SignerRef, error) {
 	ret := _m.Called(ctx, _a1)


### PR DESCRIPTION
Only the org DID is needed for this check - no need to actually look up the org from the database. At this point the message author has already been verified, so a database lookup here is just extra unnecessary processing (and can lead to infinite retries if it fails).

Port of #1398