### PR TITLE
Call ResolveFFI from GenerateFFI

### DIFF
--- a/internal/contracts/manager.go
+++ b/internal/contracts/manager.go
@@ -995,7 +995,11 @@ func (cm *contractManager) checkParamSchema(ctx context.Context, name string, in
 
 func (cm *contractManager) GenerateFFI(ctx context.Context, generationRequest *fftypes.FFIGenerationRequest) (*fftypes.FFI, error) {
 	generationRequest.Namespace = cm.namespace
-	return cm.blockchain.GenerateFFI(ctx, generationRequest)
+	ffi, err := cm.blockchain.GenerateFFI(ctx, generationRequest)
+	if err == nil {
+		err = cm.ResolveFFI(ctx, ffi)
+	}
+	return ffi, err
 }
 
 func (cm *contractManager) getDefaultContractListenerOptions() *core.ContractListenerOptions {

--- a/internal/contracts/manager_test.go
+++ b/internal/contracts/manager_test.go
@@ -3554,12 +3554,25 @@ func TestGenerateFFI(t *testing.T) {
 	cm := newTestContractManager()
 	mbi := cm.blockchain.(*blockchainmocks.Plugin)
 	mbi.On("GenerateFFI", mock.Anything, mock.Anything).Return(&fftypes.FFI{
-		Name: "generated",
+		Name:    "generated",
+		Version: "1.0",
+		Methods: []*fftypes.FFIMethod{
+			{
+				Name: "method1",
+			},
+			{
+				Name: "method1",
+			},
+		},
 	}, nil)
 	ffi, err := cm.GenerateFFI(context.Background(), &fftypes.FFIGenerationRequest{})
 	assert.NoError(t, err)
 	assert.NotNil(t, ffi)
 	assert.Equal(t, "generated", ffi.Name)
+	assert.Equal(t, "method1", ffi.Methods[0].Name)
+	assert.Equal(t, "method1", ffi.Methods[0].Pathname)
+	assert.Equal(t, "method1", ffi.Methods[1].Name)
+	assert.Equal(t, "method1_1", ffi.Methods[1].Pathname)
 }
 
 type MockFFIParamValidator struct{}


### PR DESCRIPTION
Ensures that the generated FFI is valid and has pathnames for each method.

Port of https://github.com/hyperledger/firefly/pull/1423