### PR TITLE
Allow blank signing key for queries on Ethereum

### DIFF
--- a/internal/blockchain/ethereum/ethereum.go
+++ b/internal/blockchain/ethereum/ethereum.go
@@ -548,6 +548,13 @@ func formatEthAddress(ctx context.Context, key string) (string, error) {
 }
 
 func (e *Ethereum) ResolveSigningKey(ctx context.Context, key string, intent blockchain.ResolveKeyIntent) (resolved string, err error) {
+	// Key may be unset for query intent only
+	if key == "" {
+		if intent == blockchain.ResolveKeyIntentQuery {
+			return "", nil
+		}
+		return "", i18n.NewError(ctx, coremsgs.MsgNodeMissingBlockchainKey)
+	}
 	if !e.addressResolveAlways {
 		// If there's no address resolver plugin, or addressResolveAlways is false,
 		// we check if it's already an ethereum address - in which case we can just return it.
@@ -649,7 +656,7 @@ func (e *Ethereum) queryContractMethod(ctx context.Context, address, signingKey 
 	return res, nil
 }
 
-func (e *Ethereum) buildBatchPinInput(ctx context.Context, version int, namespace string, batch *blockchain.BatchPin) (*abi.Entry, []interface{}) {
+func (e *Ethereum) buildBatchPinInput(version int, namespace string, batch *blockchain.BatchPin) (*abi.Entry, []interface{}) {
 	ethHashes := make([]string, len(batch.Contexts))
 	for i, v := range batch.Contexts {
 		ethHashes[i] = ethHexFormatB32(v)
@@ -694,7 +701,7 @@ func (e *Ethereum) SubmitBatchPin(ctx context.Context, nsOpID, networkNamespace,
 		return err
 	}
 
-	method, input := e.buildBatchPinInput(ctx, version, networkNamespace, batch)
+	method, input := e.buildBatchPinInput(version, networkNamespace, batch)
 
 	var emptyErrors []*abi.Entry
 	_, err = e.invokeContractMethod(ctx, ethLocation.Address, signingKey, method, nsOpID, input, emptyErrors, nil)
@@ -810,7 +817,7 @@ func (e *Ethereum) InvokeContract(ctx context.Context, nsOpID string, signingKey
 	if batch != nil {
 		err := e.checkDataSupport(ctx, methodInfo.methodABI)
 		if err == nil {
-			method, batchPin := e.buildBatchPinInput(ctx, 2, "", batch)
+			method, batchPin := e.buildBatchPinInput(2, "", batch)
 			encoded, err := method.Inputs.EncodeABIDataValuesCtx(ctx, batchPin)
 			if err == nil {
 				orderedInput[len(orderedInput)-1] = hex.EncodeToString(encoded)

--- a/internal/blockchain/ethereum/ethereum_test.go
+++ b/internal/blockchain/ethereum/ethereum_test.go
@@ -152,7 +152,7 @@ func newTestStreamManager(client *resty.Client) *streamManager {
 	return newStreamManager(client, cache.NewUmanagedCache(context.Background(), 100, 5*time.Minute), defaultBatchSize, defaultBatchTimeout)
 }
 
-func mockNetworkVersion(t *testing.T, version int) func(req *http.Request) (*http.Response, error) {
+func mockNetworkVersion(version int) func(req *http.Request) (*http.Response, error) {
 	return func(req *http.Request) (*http.Response, error) {
 		readBody, _ := req.GetBody()
 		var body map[string]interface{}
@@ -569,7 +569,7 @@ func TestEthCacheInitFail(t *testing.T) {
 			"registeredAs": "firefly",
 		}),
 	)
-	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(t, 1))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(1))
 
 	e, cancel := newTestEthereum()
 	resetConf(e)
@@ -617,7 +617,7 @@ func TestInitOldInstancePathContracts(t *testing.T) {
 			"registeredAs": "firefly",
 		}),
 	)
-	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(t, 1))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(1))
 
 	resetConf(e)
 	utEthconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
@@ -654,7 +654,7 @@ func TestInitOldInstancePathInstances(t *testing.T) {
 			assert.Equal(t, "es12345", body["stream"])
 			return httpmock.NewJsonResponderOrPanic(200, subscription{ID: "sub12345"})(req)
 		})
-	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(t, 1))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(1))
 
 	resetConf(e)
 	utEthconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
@@ -848,7 +848,7 @@ func TestInitAllExistingStreams(t *testing.T) {
 		}))
 	httpmock.RegisterResponder("PATCH", "http://localhost:12345/eventstreams/es12345",
 		httpmock.NewJsonResponderOrPanic(200, &eventStream{ID: "es12345", Name: "topic1"}))
-	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(t, 2))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(2))
 	httpmock.RegisterResponder("POST", "http://localhost:12345/subscriptions",
 		httpmock.NewJsonResponderOrPanic(200, subscription{}))
 
@@ -894,7 +894,7 @@ func TestInitAllExistingStreamsV1(t *testing.T) {
 		}))
 	httpmock.RegisterResponder("PATCH", "http://localhost:12345/eventstreams/es12345",
 		httpmock.NewJsonResponderOrPanic(200, &eventStream{ID: "es12345", Name: "topic1"}))
-	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(t, 1))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(1))
 	httpmock.RegisterResponder("POST", "http://localhost:12345/subscriptions",
 		httpmock.NewJsonResponderOrPanic(200, subscription{}))
 
@@ -940,7 +940,7 @@ func TestInitAllExistingStreamsOld(t *testing.T) {
 		}))
 	httpmock.RegisterResponder("PATCH", "http://localhost:12345/eventstreams/es12345",
 		httpmock.NewJsonResponderOrPanic(200, &eventStream{ID: "es12345", Name: "topic1"}))
-	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(t, 1))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(1))
 	httpmock.RegisterResponder("POST", "http://localhost:12345/subscriptions",
 		httpmock.NewJsonResponderOrPanic(200, subscription{}))
 
@@ -986,7 +986,7 @@ func TestInitAllExistingStreamsInvalidName(t *testing.T) {
 		}))
 	httpmock.RegisterResponder("PATCH", "http://localhost:12345/eventstreams/es12345",
 		httpmock.NewJsonResponderOrPanic(200, &eventStream{ID: "es12345", Name: "topic1"}))
-	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(t, 2))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(2))
 	httpmock.RegisterResponder("POST", "http://localhost:12345/subscriptions",
 		httpmock.NewJsonResponderOrPanic(200, subscription{}))
 
@@ -1093,7 +1093,7 @@ func TestSubmitBatchPinOK(t *testing.T) {
 
 	httpmock.RegisterResponder("POST", `http://localhost:12345/`,
 		func(req *http.Request) (*http.Response, error) {
-			res, err := mockNetworkVersion(t, 2)(req)
+			res, err := mockNetworkVersion(2)(req)
 			if res != nil || err != nil {
 				return res, err
 			}
@@ -1137,7 +1137,7 @@ func TestSubmitBatchPinV1(t *testing.T) {
 
 	httpmock.RegisterResponder("POST", `http://localhost:12345/`,
 		func(req *http.Request) (*http.Response, error) {
-			res, err := mockNetworkVersion(t, 1)(req)
+			res, err := mockNetworkVersion(1)(req)
 			if res != nil || err != nil {
 				return res, err
 			}
@@ -1207,7 +1207,7 @@ func TestSubmitBatchEmptyPayloadRef(t *testing.T) {
 
 	httpmock.RegisterResponder("POST", `http://localhost:12345/`,
 		func(req *http.Request) (*http.Response, error) {
-			res, err := mockNetworkVersion(t, 2)(req)
+			res, err := mockNetworkVersion(2)(req)
 			if res != nil || err != nil {
 				return res, err
 			}
@@ -1288,7 +1288,7 @@ func TestSubmitBatchPinFail(t *testing.T) {
 
 	httpmock.RegisterResponder("POST", `http://localhost:12345/`,
 		func(req *http.Request) (*http.Response, error) {
-			res, err := mockNetworkVersion(t, 2)(req)
+			res, err := mockNetworkVersion(2)(req)
 			if res != nil || err != nil {
 				return res, err
 			}
@@ -1326,7 +1326,7 @@ func TestSubmitBatchPinError(t *testing.T) {
 
 	httpmock.RegisterResponder("POST", `http://localhost:12345/`,
 		func(req *http.Request) (*http.Response, error) {
-			res, err := mockNetworkVersion(t, 2)(req)
+			res, err := mockNetworkVersion(2)(req)
 			if res != nil || err != nil {
 				return res, err
 			}
@@ -1344,10 +1344,17 @@ func TestVerifyEthAddress(t *testing.T) {
 	e, cancel := newTestEthereum()
 	defer cancel()
 
-	_, err := e.ResolveSigningKey(context.Background(), "0x12345", blockchain.ResolveKeyIntentSign)
+	_, err := e.ResolveSigningKey(context.Background(), "", blockchain.ResolveKeyIntentSign)
+	assert.Regexp(t, "FF10354", err)
+
+	key, err := e.ResolveSigningKey(context.Background(), "", blockchain.ResolveKeyIntentQuery)
+	assert.NoError(t, err)
+	assert.Empty(t, key)
+
+	_, err = e.ResolveSigningKey(context.Background(), "0x12345", blockchain.ResolveKeyIntentSign)
 	assert.Regexp(t, "FF10141", err)
 
-	key, err := e.ResolveSigningKey(context.Background(), "0x2a7c9D5248681CE6c393117E641aD037F5C079F6", blockchain.ResolveKeyIntentSign)
+	key, err = e.ResolveSigningKey(context.Background(), "0x2a7c9D5248681CE6c393117E641aD037F5C079F6", blockchain.ResolveKeyIntentSign)
 	assert.NoError(t, err)
 	assert.Equal(t, "0x2a7c9d5248681ce6c393117e641ad037f5c079f6", key)
 
@@ -3472,7 +3479,7 @@ func TestSubmitNetworkAction(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	httpmock.RegisterResponder("POST", `http://localhost:12345/`,
 		func(req *http.Request) (*http.Response, error) {
-			res, err := mockNetworkVersion(t, 2)(req)
+			res, err := mockNetworkVersion(2)(req)
 			if res != nil || err != nil {
 				return res, err
 			}
@@ -3501,7 +3508,7 @@ func TestSubmitNetworkActionV1(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	httpmock.RegisterResponder("POST", `http://localhost:12345/`,
 		func(req *http.Request) (*http.Response, error) {
-			res, err := mockNetworkVersion(t, 1)(req)
+			res, err := mockNetworkVersion(1)(req)
 			if res != nil || err != nil {
 				return res, err
 			}
@@ -3946,7 +3953,7 @@ func TestAddAndRemoveFireflySubscription(t *testing.T) {
 		httpmock.NewJsonResponderOrPanic(200, subscription{
 			ID: "sub1",
 		}))
-	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(t, 2))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(2))
 
 	utEthconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
 	utEthconnectConf.Set(ffresty.HTTPCustomClient, mockedClient)
@@ -3999,7 +4006,7 @@ func TestAddFireflySubscriptionV1(t *testing.T) {
 		httpmock.NewJsonResponderOrPanic(200, subscription{
 			ID: "sub1",
 		}))
-	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(t, 1))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(1))
 
 	utEthconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
 	utEthconnectConf.Set(ffresty.HTTPCustomClient, mockedClient)
@@ -4041,7 +4048,7 @@ func TestAddFireflySubscriptionQuerySubsFail(t *testing.T) {
 		httpmock.NewStringResponder(500, `pop`))
 	httpmock.RegisterResponder("POST", "http://localhost:12345/subscriptions",
 		httpmock.NewJsonResponderOrPanic(200, subscription{}))
-	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(t, 2))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(2))
 
 	utEthconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
 	utEthconnectConf.Set(ffresty.HTTPCustomClient, mockedClient)
@@ -4124,7 +4131,7 @@ func TestAddFireflySubscriptionGetVersionError(t *testing.T) {
 		httpmock.NewJsonResponderOrPanic(200, []subscription{}))
 	httpmock.RegisterResponder("POST", "http://localhost:12345/subscriptions",
 		httpmock.NewJsonResponderOrPanic(500, `pop`))
-	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(t, 2))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(2))
 
 	utEthconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
 	utEthconnectConf.Set(ffresty.HTTPCustomClient, mockedClient)

--- a/internal/blockchain/fabric/fabric.go
+++ b/internal/blockchain/fabric/fabric.go
@@ -569,6 +569,11 @@ func (f *Fabric) ResolveSigningKey(ctx context.Context, signingKeyInput string, 
 	//       currently pluggable to external identity resolution systems (as is the case for
 	//       ethereum blockchain connectors).
 
+	// Key is always required
+	if signingKeyInput == "" {
+		return "", i18n.NewError(ctx, coremsgs.MsgNodeMissingBlockchainKey)
+	}
+
 	// we expand the short user name into the fully qualified onchain identity:
 	// mspid::x509::{ecert DN}::{CA DN}	return signingKeyInput, nil
 	if !fullIdentityPattern.MatchString(signingKeyInput) {
@@ -652,7 +657,7 @@ func hexFormatB32(b *fftypes.Bytes32) string {
 	return "0x" + hex.EncodeToString(b[0:32])
 }
 
-func (f *Fabric) buildBatchPinInput(ctx context.Context, version int, namespace string, batch *blockchain.BatchPin) (prefixItems []*PrefixItem, pinInput map[string]interface{}) {
+func (f *Fabric) buildBatchPinInput(version int, namespace string, batch *blockchain.BatchPin) (prefixItems []*PrefixItem, pinInput map[string]interface{}) {
 	hashes := make([]string, len(batch.Contexts))
 	for i, v := range batch.Contexts {
 		hashes[i] = hexFormatB32(v)
@@ -693,7 +698,7 @@ func (f *Fabric) SubmitBatchPin(ctx context.Context, nsOpID, networkNamespace, s
 		return err
 	}
 
-	prefixItems, pinInput := f.buildBatchPinInput(ctx, version, networkNamespace, batch)
+	prefixItems, pinInput := f.buildBatchPinInput(version, networkNamespace, batch)
 
 	input, _ := jsonEncodeInput(pinInput)
 	_, err = f.invokeContractMethod(ctx, fabricOnChainLocation.Channel, fabricOnChainLocation.Chaincode, batchPinMethodName, signingKey, nsOpID, prefixItems, input, nil)
@@ -807,7 +812,7 @@ func (f *Fabric) InvokeContract(ctx context.Context, nsOpID string, signingKey s
 	}
 
 	if batch != nil {
-		_, batchPin := f.buildBatchPinInput(ctx, 2, "", batch)
+		_, batchPin := f.buildBatchPinInput(2, "", batch)
 		if input == nil {
 			input = make(map[string]interface{})
 		}

--- a/internal/blockchain/fabric/fabric_test.go
+++ b/internal/blockchain/fabric/fabric_test.go
@@ -128,7 +128,7 @@ func testFFIPinMethod() *fftypes.FFIMethod {
 	}
 }
 
-func mockNetworkVersion(t *testing.T, version float64) func(req *http.Request) (*http.Response, error) {
+func mockNetworkVersion(version float64) func(req *http.Request) (*http.Response, error) {
 	return func(req *http.Request) (*http.Response, error) {
 		var body map[string]interface{}
 		json.NewDecoder(req.Body).Decode(&body)
@@ -527,7 +527,7 @@ func TestCacheInitFail(t *testing.T) {
 			{ID: "sub12345", Stream: "es12345", Name: "ns1_BatchPin"},
 		}))
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 2))
+		mockNetworkVersion(2))
 
 	resetConf(e)
 	utFabconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
@@ -558,7 +558,7 @@ func TestInitAllExistingStreams(t *testing.T) {
 			{ID: "sub12345", Stream: "es12345", Name: "ns1_BatchPin"},
 		}))
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 2))
+		mockNetworkVersion(2))
 
 	resetConf(e)
 	utFabconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
@@ -603,7 +603,7 @@ func TestInitAllExistingStreamsV1(t *testing.T) {
 			{ID: "sub12345", Stream: "es12345", Name: "BatchPin"},
 		}))
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	resetConf(e)
 	utFabconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
@@ -643,7 +643,7 @@ func TestAddFireflySubscriptionGlobal(t *testing.T) {
 	httpmock.RegisterResponder("GET", "http://localhost:12345/subscriptions",
 		httpmock.NewJsonResponderOrPanic(200, []subscription{}))
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	httpmock.RegisterResponder("POST", `http://localhost:12345/subscriptions`,
 		func(req *http.Request) (*http.Response, error) {
@@ -693,7 +693,7 @@ func TestAddFireflySubscriptionBadOptions(t *testing.T) {
 	httpmock.RegisterResponder("GET", "http://localhost:12345/subscriptions",
 		httpmock.NewJsonResponderOrPanic(500, "pop"))
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	mockedClient := &http.Client{}
 	httpmock.ActivateNonDefault(mockedClient)
@@ -734,7 +734,7 @@ func TestAddFireflySubscriptionQuerySubsFail(t *testing.T) {
 	httpmock.RegisterResponder("GET", "http://localhost:12345/subscriptions",
 		httpmock.NewJsonResponderOrPanic(500, "pop"))
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	mockedClient := &http.Client{}
 	httpmock.ActivateNonDefault(mockedClient)
@@ -821,7 +821,7 @@ func TestAddAndRemoveFireflySubscriptionDeprecatedSubName(t *testing.T) {
 			{ID: "sub12345", Stream: "es12345", Name: "BatchPin"},
 		}))
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	resetConf(e)
 	utFabconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
@@ -870,7 +870,7 @@ func TestAddFireflySubscriptionInvalidSubName(t *testing.T) {
 			{ID: "sub12345", Stream: "es12345", Name: "BatchPin"},
 		}))
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 2))
+		mockNetworkVersion(2))
 
 	resetConf(e)
 	utFabconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
@@ -1011,7 +1011,7 @@ func TestSubQueryCreateError(t *testing.T) {
 	httpmock.RegisterResponder("POST", "http://localhost:12345/subscriptions",
 		httpmock.NewStringResponder(500, `pop`))
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	resetConf(e)
 	utFabconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
@@ -1058,7 +1058,7 @@ func TestSubQueryCreate(t *testing.T) {
 	httpmock.RegisterResponder("POST", "http://localhost:12345/subscriptions",
 		httpmock.NewJsonResponderOrPanic(200, subscription{ID: "sb-123"}))
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	resetConf(e)
 	utFabconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
@@ -1112,7 +1112,7 @@ func TestSubmitBatchPinOK(t *testing.T) {
 	}.String())
 
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 2))
+		mockNetworkVersion(2))
 
 	httpmock.RegisterResponder("POST", `http://localhost:12345/transactions`,
 		func(req *http.Request) (*http.Response, error) {
@@ -1156,7 +1156,7 @@ func TestSubmitBatchPinV1(t *testing.T) {
 	}.String())
 
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	httpmock.RegisterResponder("POST", `http://localhost:12345/transactions`,
 		func(req *http.Request) (*http.Response, error) {
@@ -1224,7 +1224,7 @@ func TestSubmitBatchEmptyPayloadRef(t *testing.T) {
 	}.String())
 
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	httpmock.RegisterResponder("POST", `http://localhost:12345/transactions`,
 		func(req *http.Request) (*http.Response, error) {
@@ -1301,7 +1301,7 @@ func TestSubmitBatchPinFail(t *testing.T) {
 	}.String())
 
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	httpmock.RegisterResponder("POST", `http://localhost:12345/transactions`,
 		httpmock.NewStringResponder(500, "pop"))
@@ -1337,7 +1337,7 @@ func TestSubmitBatchPinError(t *testing.T) {
 	}.String())
 
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	httpmock.RegisterResponder("POST", `http://localhost:12345/transactions`,
 		httpmock.NewJsonResponderOrPanic(500, fftypes.JSONObject{
@@ -1348,6 +1348,15 @@ func TestSubmitBatchPinError(t *testing.T) {
 
 	assert.Regexp(t, "FF10284.*Invalid", err)
 
+}
+
+func TestResolveSignerBlank(t *testing.T) {
+	e, cancel := newTestFabric()
+	e.idCache = make(map[string]*fabIdentity)
+	defer cancel()
+
+	_, err := e.ResolveSigningKey(context.Background(), "", blockchain.ResolveKeyIntentSign)
+	assert.Regexp(t, "FF10354", err)
 }
 
 func TestResolveFullIDSigner(t *testing.T) {
@@ -2928,7 +2937,7 @@ func TestGetNetworkVersion(t *testing.T) {
 	}.String())
 
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	version, err := e.GetNetworkVersion(context.Background(), location)
 	assert.NoError(t, err)
@@ -3092,7 +3101,7 @@ func TestSubmitNetworkAction(t *testing.T) {
 		})
 
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 2))
+		mockNetworkVersion(2))
 
 	location := fftypes.JSONAnyPtr(fftypes.JSONObject{
 		"channel":   "firefly",
@@ -3124,7 +3133,7 @@ func TestSubmitNetworkActionV1(t *testing.T) {
 		})
 
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	location := fftypes.JSONAnyPtr(fftypes.JSONObject{
 		"channel":   "firefly",

--- a/internal/blockchain/tezos/tezos.go
+++ b/internal/blockchain/tezos/tezos.go
@@ -273,6 +273,10 @@ func (t *Tezos) RemoveFireflySubscription(ctx context.Context, subID string) {
 }
 
 func (t *Tezos) ResolveSigningKey(ctx context.Context, key string, intent blockchain.ResolveKeyIntent) (resolved string, err error) {
+	// Key is always required
+	if key == "" {
+		return "", i18n.NewError(ctx, coremsgs.MsgNodeMissingBlockchainKey)
+	}
 	if !t.addressResolveAlways {
 		// If there's no address resolver plugin, or addressResolveAlways is false,
 		// we check if it's already an tezos address - in which case we can just return it.

--- a/internal/blockchain/tezos/tezos_test.go
+++ b/internal/blockchain/tezos/tezos_test.go
@@ -558,7 +558,10 @@ func TestVerifyTezosAddress(t *testing.T) {
 	tz, cancel := newTestTezos()
 	defer cancel()
 
-	_, err := tz.ResolveSigningKey(context.Background(), "tz1err", blockchain.ResolveKeyIntentSign)
+	_, err := tz.ResolveSigningKey(context.Background(), "", blockchain.ResolveKeyIntentSign)
+	assert.Regexp(t, "FF10354", err)
+
+	_, err = tz.ResolveSigningKey(context.Background(), "tz1err", blockchain.ResolveKeyIntentSign)
 	assert.Regexp(t, "FF10142", err)
 
 	key, err := tz.ResolveSigningKey(context.Background(), "tz1Y6GnVhC4EpcDDSmD3ibcC4WX6DJ4Q1QLN", blockchain.ResolveKeyIntentSign)

--- a/internal/identity/identitymanager.go
+++ b/internal/identity/identitymanager.go
@@ -311,12 +311,11 @@ func (im *identityManager) getDefaultVerifier(ctx context.Context, intent blockc
 	}
 	if im.multiparty != nil {
 		orgKey := im.multiparty.RootOrg().Key
-		if orgKey == "" {
-			return nil, i18n.NewError(ctx, coremsgs.MsgNodeMissingBlockchainKey)
+		if orgKey != "" {
+			return im.resolveInputKeyViaBlockchainPlugin(ctx, orgKey, intent)
 		}
-		return im.resolveInputKeyViaBlockchainPlugin(ctx, orgKey, intent)
 	}
-	return nil, i18n.NewError(ctx, coremsgs.MsgNodeMissingBlockchainKey)
+	return im.resolveInputKeyViaBlockchainPlugin(ctx, "", intent)
 }
 
 // ResolveMultipartyRootVerifier gets the blockchain verifier of the root org via the configuration,

--- a/internal/identity/identitymanager_test.go
+++ b/internal/identity/identitymanager_test.go
@@ -203,9 +203,12 @@ func TestResolveInputSigningIdentityNoKey(t *testing.T) {
 	mmp := im.multiparty.(*multipartymocks.Manager)
 	mmp.On("RootOrg").Return(multiparty.RootOrg{})
 
+	mbi := im.blockchain.(*blockchainmocks.Plugin)
+	mbi.On("ResolveSigningKey", ctx, "", blockchain.ResolveKeyIntentSign).Return("", fmt.Errorf("pop"))
+
 	msgIdentity := &core.SignerRef{}
 	err := im.ResolveInputSigningIdentity(ctx, msgIdentity)
-	assert.Regexp(t, "FF10354", err)
+	assert.EqualError(t, err, "pop")
 
 	mmp.AssertExpectations(t)
 
@@ -740,8 +743,11 @@ func TestResolveInputSigningKeyNoDefault(t *testing.T) {
 	ctx, im := newTestIdentityManager(t)
 	im.multiparty = nil
 
+	mbi := im.blockchain.(*blockchainmocks.Plugin)
+	mbi.On("ResolveSigningKey", ctx, "", blockchain.ResolveKeyIntentSign).Return("", fmt.Errorf("pop"))
+
 	_, err := im.ResolveInputSigningKey(ctx, "", KeyNormalizationBlockchainPlugin)
-	assert.Regexp(t, "FF10354", err)
+	assert.EqualError(t, err, "pop")
 
 }
 


### PR DESCRIPTION
Ported from https://github.com/hyperledger/firefly/pull/1514