### PR TITLE
Port into release-v1.3.0 patch branch: Allow blank signing key for queries on Ethereum

### DIFF
--- a/internal/blockchain/ethereum/ethereum.go
+++ b/internal/blockchain/ethereum/ethereum.go
@@ -542,6 +542,13 @@ func formatEthAddress(ctx context.Context, key string) (string, error) {
 }
 
 func (e *Ethereum) ResolveSigningKey(ctx context.Context, key string, intent blockchain.ResolveKeyIntent) (resolved string, err error) {
+	// Key may be unset for query intent only
+	if key == "" {
+		if intent == blockchain.ResolveKeyIntentQuery {
+			return "", nil
+		}
+		return "", i18n.NewError(ctx, coremsgs.MsgNodeMissingBlockchainKey)
+	}
 	if !e.addressResolveAlways {
 		// If there's no address resolver plugin, or addressResolveAlways is false,
 		// we check if it's already an ethereum address - in which case we can just return it.
@@ -643,7 +650,7 @@ func (e *Ethereum) queryContractMethod(ctx context.Context, address, signingKey 
 	return res, nil
 }
 
-func (e *Ethereum) buildBatchPinInput(ctx context.Context, version int, namespace string, batch *blockchain.BatchPin) (*abi.Entry, []interface{}) {
+func (e *Ethereum) buildBatchPinInput(version int, namespace string, batch *blockchain.BatchPin) (*abi.Entry, []interface{}) {
 	ethHashes := make([]string, len(batch.Contexts))
 	for i, v := range batch.Contexts {
 		ethHashes[i] = ethHexFormatB32(v)
@@ -688,7 +695,7 @@ func (e *Ethereum) SubmitBatchPin(ctx context.Context, nsOpID, networkNamespace,
 		return err
 	}
 
-	method, input := e.buildBatchPinInput(ctx, version, networkNamespace, batch)
+	method, input := e.buildBatchPinInput(version, networkNamespace, batch)
 
 	var emptyErrors []*abi.Entry
 	_, err = e.invokeContractMethod(ctx, ethLocation.Address, signingKey, method, nsOpID, input, emptyErrors, nil)
@@ -802,7 +809,7 @@ func (e *Ethereum) InvokeContract(ctx context.Context, nsOpID string, signingKey
 	if batch != nil {
 		err := e.checkDataSupport(ctx, methodInfo.methodABI)
 		if err == nil {
-			method, batchPin := e.buildBatchPinInput(ctx, 2, "", batch)
+			method, batchPin := e.buildBatchPinInput(2, "", batch)
 			encoded, err := method.Inputs.EncodeABIDataValuesCtx(ctx, batchPin)
 			if err == nil {
 				orderedInput[len(orderedInput)-1] = hex.EncodeToString(encoded)

--- a/internal/blockchain/ethereum/ethereum_test.go
+++ b/internal/blockchain/ethereum/ethereum_test.go
@@ -159,7 +159,7 @@ func newTestStreamManager(client *resty.Client) *streamManager {
 	return newStreamManager(client, cache.NewUmanagedCache(context.Background(), 100, 5*time.Minute), defaultBatchSize, defaultBatchTimeout)
 }
 
-func mockNetworkVersion(t *testing.T, version int) func(req *http.Request) (*http.Response, error) {
+func mockNetworkVersion(version int) func(req *http.Request) (*http.Response, error) {
 	return func(req *http.Request) (*http.Response, error) {
 		readBody, _ := req.GetBody()
 		var body map[string]interface{}
@@ -591,7 +591,7 @@ func TestEthCacheInitFail(t *testing.T) {
 			"registeredAs": "firefly",
 		}),
 	)
-	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(t, 1))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(1))
 
 	e, cancel := newTestEthereum()
 	resetConf(e)
@@ -639,7 +639,7 @@ func TestInitOldInstancePathContracts(t *testing.T) {
 			"registeredAs": "firefly",
 		}),
 	)
-	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(t, 1))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(1))
 
 	resetConf(e)
 	utEthconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
@@ -675,7 +675,7 @@ func TestInitOldInstancePathInstances(t *testing.T) {
 			assert.Equal(t, "es12345/ns1", body["stream"])
 			return httpmock.NewJsonResponderOrPanic(200, subscription{ID: "sub12345"})(req)
 		})
-	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(t, 1))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(1))
 
 	resetConf(e)
 	utEthconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
@@ -874,11 +874,10 @@ func TestInitAllExistingStreams(t *testing.T) {
 		httpmock.NewJsonResponderOrPanic(200, []subscription{
 			{ID: "sub12345", Stream: "es12345", Name: "ns1_BatchPin_3078373143373635" /* this is the subname for our combo of instance path and BatchPin */},
 		}))
-
-	httpmock.RegisterResponder("PATCH", fmt.Sprintf("%s/eventstreams/es12345", httpURL),
-		httpmock.NewJsonResponderOrPanic(200, &eventStream{ID: "es12345", Name: "topic1/ns1"}))
-	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/", httpURL), mockNetworkVersion(t, 2))
-	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/subscriptions", httpURL),
+	httpmock.RegisterResponder("PATCH", "http://localhost:12345/eventstreams/es12345",
+		httpmock.NewJsonResponderOrPanic(200, &eventStream{ID: "es12345", Name: "topic1"}))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(2))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/subscriptions",
 		httpmock.NewJsonResponderOrPanic(200, subscription{}))
 
 	resetConf(e)
@@ -934,10 +933,10 @@ func TestInitAllExistingStreamsV1(t *testing.T) {
 		httpmock.NewJsonResponderOrPanic(200, []subscription{
 			{ID: "sub12345", Stream: "es12345", Name: "BatchPin_3078373143373635" /* this is the subname for our combo of instance path and BatchPin */},
 		}))
-	httpmock.RegisterResponder("PATCH", fmt.Sprintf("%s/eventstreams/es12345", httpURL),
-		httpmock.NewJsonResponderOrPanic(200, &eventStream{ID: "es12345", Name: "topic1/ns1"}))
-	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/", httpURL), mockNetworkVersion(t, 1))
-	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/subscriptions", httpURL),
+	httpmock.RegisterResponder("PATCH", "http://localhost:12345/eventstreams/es12345",
+		httpmock.NewJsonResponderOrPanic(200, &eventStream{ID: "es12345", Name: "topic1"}))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(1))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/subscriptions",
 		httpmock.NewJsonResponderOrPanic(200, subscription{}))
 
 	resetConf(e)
@@ -992,10 +991,10 @@ func TestInitAllExistingStreamsOld(t *testing.T) {
 		httpmock.NewJsonResponderOrPanic(200, []subscription{
 			{ID: "sub12345", Stream: "es12345", Name: "BatchPin"},
 		}))
-	httpmock.RegisterResponder("PATCH", fmt.Sprintf("%s/eventstreams/es12345", httpURL),
-		httpmock.NewJsonResponderOrPanic(200, &eventStream{ID: "es12345", Name: "topic1/ns1"}))
-	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/", httpURL), mockNetworkVersion(t, 1))
-	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/subscriptions", httpURL),
+	httpmock.RegisterResponder("PATCH", "http://localhost:12345/eventstreams/es12345",
+		httpmock.NewJsonResponderOrPanic(200, &eventStream{ID: "es12345", Name: "topic1"}))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(1))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/subscriptions",
 		httpmock.NewJsonResponderOrPanic(200, subscription{}))
 
 	resetConf(e)
@@ -1050,10 +1049,10 @@ func TestInitAllExistingStreamsInvalidName(t *testing.T) {
 		httpmock.NewJsonResponderOrPanic(200, []subscription{
 			{ID: "sub12345", Stream: "es12345", Name: "BatchPin_3078373143373635" /* this is the subname for our combo of instance path and BatchPin */},
 		}))
-	httpmock.RegisterResponder("PATCH", fmt.Sprintf("%s/eventstreams/es12345", httpURL),
-		httpmock.NewJsonResponderOrPanic(200, &eventStream{ID: "es12345", Name: "topic1/ns1"}))
-	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/", httpURL), mockNetworkVersion(t, 2))
-	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/subscriptions", httpURL),
+	httpmock.RegisterResponder("PATCH", "http://localhost:12345/eventstreams/es12345",
+		httpmock.NewJsonResponderOrPanic(200, &eventStream{ID: "es12345", Name: "topic1"}))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(2))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/subscriptions",
 		httpmock.NewJsonResponderOrPanic(200, subscription{}))
 
 	resetConf(e)
@@ -1164,7 +1163,7 @@ func TestSubmitBatchPinOK(t *testing.T) {
 
 	httpmock.RegisterResponder("POST", `http://localhost:12345/`,
 		func(req *http.Request) (*http.Response, error) {
-			res, err := mockNetworkVersion(t, 2)(req)
+			res, err := mockNetworkVersion(2)(req)
 			if res != nil || err != nil {
 				return res, err
 			}
@@ -1208,7 +1207,7 @@ func TestSubmitBatchPinV1(t *testing.T) {
 
 	httpmock.RegisterResponder("POST", `http://localhost:12345/`,
 		func(req *http.Request) (*http.Response, error) {
-			res, err := mockNetworkVersion(t, 1)(req)
+			res, err := mockNetworkVersion(1)(req)
 			if res != nil || err != nil {
 				return res, err
 			}
@@ -1278,7 +1277,7 @@ func TestSubmitBatchEmptyPayloadRef(t *testing.T) {
 
 	httpmock.RegisterResponder("POST", `http://localhost:12345/`,
 		func(req *http.Request) (*http.Response, error) {
-			res, err := mockNetworkVersion(t, 2)(req)
+			res, err := mockNetworkVersion(2)(req)
 			if res != nil || err != nil {
 				return res, err
 			}
@@ -1359,7 +1358,7 @@ func TestSubmitBatchPinFail(t *testing.T) {
 
 	httpmock.RegisterResponder("POST", `http://localhost:12345/`,
 		func(req *http.Request) (*http.Response, error) {
-			res, err := mockNetworkVersion(t, 2)(req)
+			res, err := mockNetworkVersion(2)(req)
 			if res != nil || err != nil {
 				return res, err
 			}
@@ -1397,7 +1396,7 @@ func TestSubmitBatchPinError(t *testing.T) {
 
 	httpmock.RegisterResponder("POST", `http://localhost:12345/`,
 		func(req *http.Request) (*http.Response, error) {
-			res, err := mockNetworkVersion(t, 2)(req)
+			res, err := mockNetworkVersion(2)(req)
 			if res != nil || err != nil {
 				return res, err
 			}
@@ -1415,10 +1414,17 @@ func TestVerifyEthAddress(t *testing.T) {
 	e, cancel := newTestEthereum()
 	defer cancel()
 
-	_, err := e.ResolveSigningKey(context.Background(), "0x12345", blockchain.ResolveKeyIntentSign)
+	_, err := e.ResolveSigningKey(context.Background(), "", blockchain.ResolveKeyIntentSign)
+	assert.Regexp(t, "FF10354", err)
+
+	key, err := e.ResolveSigningKey(context.Background(), "", blockchain.ResolveKeyIntentQuery)
+	assert.NoError(t, err)
+	assert.Empty(t, key)
+
+	_, err = e.ResolveSigningKey(context.Background(), "0x12345", blockchain.ResolveKeyIntentSign)
 	assert.Regexp(t, "FF10141", err)
 
-	key, err := e.ResolveSigningKey(context.Background(), "0x2a7c9D5248681CE6c393117E641aD037F5C079F6", blockchain.ResolveKeyIntentSign)
+	key, err = e.ResolveSigningKey(context.Background(), "0x2a7c9D5248681CE6c393117E641aD037F5C079F6", blockchain.ResolveKeyIntentSign)
 	assert.NoError(t, err)
 	assert.Equal(t, "0x2a7c9d5248681ce6c393117e641ad037f5c079f6", key)
 
@@ -3547,7 +3553,7 @@ func TestSubmitNetworkAction(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	httpmock.RegisterResponder("POST", `http://localhost:12345/`,
 		func(req *http.Request) (*http.Response, error) {
-			res, err := mockNetworkVersion(t, 2)(req)
+			res, err := mockNetworkVersion(2)(req)
 			if res != nil || err != nil {
 				return res, err
 			}
@@ -3576,7 +3582,7 @@ func TestSubmitNetworkActionV1(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	httpmock.RegisterResponder("POST", `http://localhost:12345/`,
 		func(req *http.Request) (*http.Response, error) {
-			res, err := mockNetworkVersion(t, 1)(req)
+			res, err := mockNetworkVersion(1)(req)
 			if res != nil || err != nil {
 				return res, err
 			}
@@ -4021,7 +4027,7 @@ func TestAddAndRemoveFireflySubscription(t *testing.T) {
 		httpmock.NewJsonResponderOrPanic(200, subscription{
 			ID: "sub1",
 		}))
-	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(t, 2))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(2))
 
 	utEthconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
 	utEthconnectConf.Set(ffresty.HTTPCustomClient, mockedClient)
@@ -4075,7 +4081,7 @@ func TestAddFireflySubscriptionV1(t *testing.T) {
 		httpmock.NewJsonResponderOrPanic(200, subscription{
 			ID: "sub1",
 		}))
-	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(t, 1))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(1))
 
 	utEthconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
 	utEthconnectConf.Set(ffresty.HTTPCustomClient, mockedClient)
@@ -4161,7 +4167,7 @@ func TestAddFireflySubscriptionQuerySubsFail(t *testing.T) {
 		httpmock.NewStringResponder(500, `pop`))
 	httpmock.RegisterResponder("POST", "http://localhost:12345/subscriptions",
 		httpmock.NewJsonResponderOrPanic(200, subscription{}))
-	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(t, 2))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(2))
 
 	utEthconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
 	utEthconnectConf.Set(ffresty.HTTPCustomClient, mockedClient)
@@ -4245,7 +4251,7 @@ func TestAddFireflySubscriptionGetVersionError(t *testing.T) {
 		httpmock.NewJsonResponderOrPanic(200, []subscription{}))
 	httpmock.RegisterResponder("POST", "http://localhost:12345/subscriptions",
 		httpmock.NewJsonResponderOrPanic(500, `pop`))
-	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(t, 2))
+	httpmock.RegisterResponder("POST", "http://localhost:12345/", mockNetworkVersion(2))
 
 	utEthconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
 	utEthconnectConf.Set(ffresty.HTTPCustomClient, mockedClient)

--- a/internal/blockchain/fabric/fabric_test.go
+++ b/internal/blockchain/fabric/fabric_test.go
@@ -130,7 +130,7 @@ func testFFIPinMethod() *fftypes.FFIMethod {
 	}
 }
 
-func mockNetworkVersion(t *testing.T, version float64) func(req *http.Request) (*http.Response, error) {
+func mockNetworkVersion(version float64) func(req *http.Request) (*http.Response, error) {
 	return func(req *http.Request) (*http.Response, error) {
 		var body map[string]interface{}
 		json.NewDecoder(req.Body).Decode(&body)
@@ -375,7 +375,7 @@ func TestCacheInitFail(t *testing.T) {
 			{ID: "sub12345", Stream: "es12345", Name: "ns1_BatchPin"},
 		}))
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 2))
+		mockNetworkVersion(2))
 
 	resetConf(e)
 	utFabconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
@@ -412,8 +412,8 @@ func TestInitAllExistingStreams(t *testing.T) {
 		httpmock.NewJsonResponderOrPanic(200, []subscription{
 			{ID: "sub12345", Stream: "es12345", Name: "ns1_BatchPin"},
 		}))
-	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/query", httpURL),
-		mockNetworkVersion(t, 2))
+	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
+		mockNetworkVersion(2))
 
 	resetConf(e)
 	utFabconnectConf.Set(ffresty.HTTPConfigURL, httpURL)
@@ -470,8 +470,8 @@ func TestInitAllExistingStreamsV1(t *testing.T) {
 		httpmock.NewJsonResponderOrPanic(200, []subscription{
 			{ID: "sub12345", Stream: "es12345", Name: "BatchPin"},
 		}))
-	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/query", httpURL),
-		mockNetworkVersion(t, 1))
+	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
+		mockNetworkVersion(1))
 
 	resetConf(e)
 	utFabconnectConf.Set(ffresty.HTTPConfigURL, httpURL)
@@ -517,7 +517,7 @@ func TestAddFireflySubscriptionGlobal(t *testing.T) {
 	httpmock.RegisterResponder("GET", "http://localhost:12345/subscriptions",
 		httpmock.NewJsonResponderOrPanic(200, []subscription{}))
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	httpmock.RegisterResponder("POST", `http://localhost:12345/subscriptions`,
 		func(req *http.Request) (*http.Response, error) {
@@ -618,7 +618,7 @@ func TestAddFireflySubscriptionBadOptions(t *testing.T) {
 	httpmock.RegisterResponder("GET", "http://localhost:12345/subscriptions",
 		httpmock.NewJsonResponderOrPanic(500, "pop"))
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	mockedClient := &http.Client{}
 	httpmock.ActivateNonDefault(mockedClient)
@@ -660,7 +660,7 @@ func TestAddFireflySubscriptionQuerySubsFail(t *testing.T) {
 	httpmock.RegisterResponder("GET", "http://localhost:12345/subscriptions",
 		httpmock.NewJsonResponderOrPanic(500, "pop"))
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	mockedClient := &http.Client{}
 	httpmock.ActivateNonDefault(mockedClient)
@@ -754,8 +754,8 @@ func TestAddAndRemoveFireflySubscriptionDeprecatedSubName(t *testing.T) {
 		httpmock.NewJsonResponderOrPanic(200, []subscription{
 			{ID: "sub12345", Stream: "es12345", Name: "BatchPin"},
 		}))
-	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/query", httpURL),
-		mockNetworkVersion(t, 1))
+	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
+		mockNetworkVersion(1))
 
 	resetConf(e)
 	utFabconnectConf.Set(ffresty.HTTPConfigURL, httpURL)
@@ -816,8 +816,8 @@ func TestAddFireflySubscriptionInvalidSubName(t *testing.T) {
 		httpmock.NewJsonResponderOrPanic(200, []subscription{
 			{ID: "sub12345", Stream: "es12345", Name: "BatchPin"},
 		}))
-	httpmock.RegisterResponder("POST", fmt.Sprintf("%s/query", httpURL),
-		mockNetworkVersion(t, 2))
+	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
+		mockNetworkVersion(2))
 
 	resetConf(e)
 	utFabconnectConf.Set(ffresty.HTTPConfigURL, httpURL)
@@ -1066,7 +1066,7 @@ func TestSubQueryCreateError(t *testing.T) {
 	httpmock.RegisterResponder("POST", "http://localhost:12345/subscriptions",
 		httpmock.NewStringResponder(500, `pop`))
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	resetConf(e)
 	utFabconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
@@ -1114,7 +1114,7 @@ func TestSubQueryCreate(t *testing.T) {
 	httpmock.RegisterResponder("POST", "http://localhost:12345/subscriptions",
 		httpmock.NewJsonResponderOrPanic(200, subscription{ID: "sb-123"}))
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	resetConf(e)
 	utFabconnectConf.Set(ffresty.HTTPConfigURL, "http://localhost:12345")
@@ -1169,7 +1169,7 @@ func TestSubmitBatchPinOK(t *testing.T) {
 	}.String())
 
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 2))
+		mockNetworkVersion(2))
 
 	httpmock.RegisterResponder("POST", `http://localhost:12345/transactions`,
 		func(req *http.Request) (*http.Response, error) {
@@ -1213,7 +1213,7 @@ func TestSubmitBatchPinV1(t *testing.T) {
 	}.String())
 
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	httpmock.RegisterResponder("POST", `http://localhost:12345/transactions`,
 		func(req *http.Request) (*http.Response, error) {
@@ -1281,7 +1281,7 @@ func TestSubmitBatchEmptyPayloadRef(t *testing.T) {
 	}.String())
 
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	httpmock.RegisterResponder("POST", `http://localhost:12345/transactions`,
 		func(req *http.Request) (*http.Response, error) {
@@ -1358,7 +1358,7 @@ func TestSubmitBatchPinFail(t *testing.T) {
 	}.String())
 
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	httpmock.RegisterResponder("POST", `http://localhost:12345/transactions`,
 		httpmock.NewStringResponder(500, "pop"))
@@ -1394,7 +1394,7 @@ func TestSubmitBatchPinError(t *testing.T) {
 	}.String())
 
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	httpmock.RegisterResponder("POST", `http://localhost:12345/transactions`,
 		httpmock.NewJsonResponderOrPanic(500, fftypes.JSONObject{
@@ -1405,6 +1405,15 @@ func TestSubmitBatchPinError(t *testing.T) {
 
 	assert.Regexp(t, "FF10284.*Invalid", err)
 
+}
+
+func TestResolveSignerBlank(t *testing.T) {
+	e, cancel := newTestFabric()
+	e.idCache = make(map[string]*fabIdentity)
+	defer cancel()
+
+	_, err := e.ResolveSigningKey(context.Background(), "", blockchain.ResolveKeyIntentSign)
+	assert.Regexp(t, "FF10354", err)
 }
 
 func TestResolveFullIDSigner(t *testing.T) {
@@ -2989,7 +2998,7 @@ func TestGetNetworkVersion(t *testing.T) {
 	}.String())
 
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	version, err := e.GetNetworkVersion(context.Background(), location)
 	assert.NoError(t, err)
@@ -3153,7 +3162,7 @@ func TestSubmitNetworkAction(t *testing.T) {
 		})
 
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 2))
+		mockNetworkVersion(2))
 
 	location := fftypes.JSONAnyPtr(fftypes.JSONObject{
 		"channel":   "firefly",
@@ -3185,7 +3194,7 @@ func TestSubmitNetworkActionV1(t *testing.T) {
 		})
 
 	httpmock.RegisterResponder("POST", fmt.Sprintf("http://localhost:12345/query"),
-		mockNetworkVersion(t, 1))
+		mockNetworkVersion(1))
 
 	location := fftypes.JSONAnyPtr(fftypes.JSONObject{
 		"channel":   "firefly",

--- a/internal/blockchain/tezos/tezos.go
+++ b/internal/blockchain/tezos/tezos.go
@@ -283,6 +283,10 @@ func (t *Tezos) RemoveFireflySubscription(ctx context.Context, subID string) {
 }
 
 func (t *Tezos) ResolveSigningKey(ctx context.Context, key string, intent blockchain.ResolveKeyIntent) (resolved string, err error) {
+	// Key is always required
+	if key == "" {
+		return "", i18n.NewError(ctx, coremsgs.MsgNodeMissingBlockchainKey)
+	}
 	if !t.addressResolveAlways {
 		// If there's no address resolver plugin, or addressResolveAlways is false,
 		// we check if it's already an tezos address - in which case we can just return it.

--- a/internal/blockchain/tezos/tezos_test.go
+++ b/internal/blockchain/tezos/tezos_test.go
@@ -559,7 +559,10 @@ func TestVerifyTezosAddress(t *testing.T) {
 	tz, cancel := newTestTezos()
 	defer cancel()
 
-	_, err := tz.ResolveSigningKey(context.Background(), "tz1err", blockchain.ResolveKeyIntentSign)
+	_, err := tz.ResolveSigningKey(context.Background(), "", blockchain.ResolveKeyIntentSign)
+	assert.Regexp(t, "FF10354", err)
+
+	_, err = tz.ResolveSigningKey(context.Background(), "tz1err", blockchain.ResolveKeyIntentSign)
 	assert.Regexp(t, "FF10142", err)
 
 	key, err := tz.ResolveSigningKey(context.Background(), "tz1Y6GnVhC4EpcDDSmD3ibcC4WX6DJ4Q1QLN", blockchain.ResolveKeyIntentSign)

--- a/internal/identity/identitymanager.go
+++ b/internal/identity/identitymanager.go
@@ -311,12 +311,11 @@ func (im *identityManager) getDefaultVerifier(ctx context.Context, intent blockc
 	}
 	if im.multiparty != nil {
 		orgKey := im.multiparty.RootOrg().Key
-		if orgKey == "" {
-			return nil, i18n.NewError(ctx, coremsgs.MsgNodeMissingBlockchainKey)
+		if orgKey != "" {
+			return im.resolveInputKeyViaBlockchainPlugin(ctx, orgKey, intent)
 		}
-		return im.resolveInputKeyViaBlockchainPlugin(ctx, orgKey, intent)
 	}
-	return nil, i18n.NewError(ctx, coremsgs.MsgNodeMissingBlockchainKey)
+	return im.resolveInputKeyViaBlockchainPlugin(ctx, "", intent)
 }
 
 // ResolveMultipartyRootVerifier gets the blockchain verifier of the root org via the configuration,

--- a/internal/identity/identitymanager_test.go
+++ b/internal/identity/identitymanager_test.go
@@ -203,9 +203,12 @@ func TestResolveInputSigningIdentityNoKey(t *testing.T) {
 	mmp := im.multiparty.(*multipartymocks.Manager)
 	mmp.On("RootOrg").Return(multiparty.RootOrg{})
 
+	mbi := im.blockchain.(*blockchainmocks.Plugin)
+	mbi.On("ResolveSigningKey", ctx, "", blockchain.ResolveKeyIntentSign).Return("", fmt.Errorf("pop"))
+
 	msgIdentity := &core.SignerRef{}
 	err := im.ResolveInputSigningIdentity(ctx, msgIdentity)
-	assert.Regexp(t, "FF10354", err)
+	assert.EqualError(t, err, "pop")
 
 	mmp.AssertExpectations(t)
 
@@ -740,8 +743,11 @@ func TestResolveInputSigningKeyNoDefault(t *testing.T) {
 	ctx, im := newTestIdentityManager(t)
 	im.multiparty = nil
 
+	mbi := im.blockchain.(*blockchainmocks.Plugin)
+	mbi.On("ResolveSigningKey", ctx, "", blockchain.ResolveKeyIntentSign).Return("", fmt.Errorf("pop"))
+
 	_, err := im.ResolveInputSigningKey(ctx, "", KeyNormalizationBlockchainPlugin)
-	assert.Regexp(t, "FF10354", err)
+	assert.EqualError(t, err, "pop")
 
 }
 


### PR DESCRIPTION
First PR to test the new release branches and protection and this fix needs to be added to this v1.3.0 patch branch