### PR TITLE
[dataexchange] Fixing Deadlock on Reconnect

### DIFF
--- a/internal/dataexchange/ffdx/ffdx.go
+++ b/internal/dataexchange/ffdx/ffdx.go
@@ -305,11 +305,12 @@ func (h *FFDX) beforeConnect(ctx context.Context, w wsclient.WSClient) error {
 		}
 	}
 
+	h.initialized = true
+
 	for _, cb := range h.callbacks.handlers {
 		cb.DXConnect(h)
 	}
 
-	h.initialized = true
 	return nil
 }
 
@@ -463,10 +464,6 @@ func (h *FFDX) TransferBlob(ctx context.Context, nsOpID string, peer, sender fft
 }
 
 func (h *FFDX) CheckNodeIdentityStatus(ctx context.Context, node *core.Identity) error {
-	if err := h.checkInitialized(ctx); err != nil {
-		return err
-	}
-
 	if node == nil {
 		return i18n.NewError(ctx, coremsgs.MsgNodeNotProvidedForCheck)
 	}

--- a/internal/dataexchange/ffdx/ffdx_test.go
+++ b/internal/dataexchange/ffdx/ffdx_test.go
@@ -1102,17 +1102,9 @@ BAYTAkFVMRMwEQYDVQQIDApxdWVlbnNsYW5kMREwDwYDVQQHDAhCcm9va2ZpZWxk
 	assert.ErrorContains(t, err, "failed to parse non-certificate within bundle")
 }
 
-func TestCheckNodeIdentityStatusReturnsErrorWhenNotInitialized(t *testing.T) {
-	h := &FFDX{initialized: false}
-	err := h.CheckNodeIdentityStatus(context.Background(), &core.Identity{})
-	assert.Regexp(t, "FF10342", err)
-}
-
 func TestCheckNodeIdentityStatusNodeNil(t *testing.T) {
 	mmm := metricsmocks.NewManager(t)
-
-	h := &FFDX{initialized: true, metrics: mmm}
-
+	h := &FFDX{metrics: mmm}
 	err := h.CheckNodeIdentityStatus(context.Background(), nil)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
If you restart a DX FF is connected to, it will cause FF to initialize and reconnect to it.

But with the recent https://github.com/hyperledger/firefly/pull/1652, we want to check the node's identity status relative to the DX config, but we wrongfully checked if the DX plugin was initialized - causing a deadlock since during reconnect we are holding the lock that re-initializes the plugin 🔁 .

It's safe to check the node identity status when we are not initialized since it is the same thing as `GetEndpointInfo` with some extra work.