### PR TITLE
Cherrypick PR #1716 from upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,7 +106,7 @@ RUN mkdir /firefly/frontend \
 
 # Final executable build
 FROM $BASE_TAG
-# Makes an assumption that that base image is ubuntu based 
+# Makes an assumption that that base image is ubuntu based
 # so it uses apt
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y \

--- a/internal/operations/operation_updater.go
+++ b/internal/operations/operation_updater.go
@@ -18,11 +18,8 @@ package operations
 
 import (
 	"context"
-	"encoding/hex"
 	"fmt"
-	"strings"
 	"time"
-	"unicode/utf8"
 
 	"github.com/hyperledger/firefly-common/pkg/config"
 	"github.com/hyperledger/firefly-common/pkg/ffapi"
@@ -35,6 +32,7 @@ import (
 	"github.com/hyperledger/firefly/internal/txcommon"
 	"github.com/hyperledger/firefly/pkg/core"
 	"github.com/hyperledger/firefly/pkg/database"
+	"github.com/hyperledger/firefly/pkg/utils"
 )
 
 type operationUpdaterBatch struct {
@@ -424,16 +422,8 @@ func (ou *operationUpdater) resolveOperation(ctx context.Context, ns string, id 
 	if status != "" {
 		update = update.Set("status", status)
 	}
-	if errorMsg != nil {
-		// PostgreSQL text columns reject null bytes and invalid UTF-8 sequences.
-		// Null bytes (0x00) are valid UTF-8 but rejected by PostgreSQL, so check both.
-		if !utf8.ValidString(*errorMsg) || strings.ContainsRune(*errorMsg, 0) {
-			hexString := hex.EncodeToString([]byte(*errorMsg))
-			log.L(ctx).Warnf("Error message contains invalid UTF-8 or null bytes - encoding as hex: %s", hexString)
-			update = update.Set("error", hexString)
-		} else {
-			update = update.Set("error", *errorMsg)
-		}
+	if safeErr, ok := utils.DBSafeUTF8StringFromPtr(ctx, errorMsg); ok {
+		update = update.Set("error", safeErr)
 	}
 	if output != nil {
 		update = update.Set("output", output)

--- a/internal/operations/operation_updater.go
+++ b/internal/operations/operation_updater.go
@@ -422,8 +422,8 @@ func (ou *operationUpdater) resolveOperation(ctx context.Context, ns string, id 
 	if status != "" {
 		update = update.Set("status", status)
 	}
-	if safeErr, ok := utils.DBSafeUTF8StringFromPtr(ctx, errorMsg); ok {
-		update = update.Set("error", safeErr)
+	if errorMsg != nil {
+		update = update.Set("error", utils.DBSafeUTF8StringFromPtr(ctx, errorMsg))
 	}
 	if output != nil {
 		update = update.Set("output", output)

--- a/pkg/utils/dbstring.go
+++ b/pkg/utils/dbstring.go
@@ -1,0 +1,42 @@
+// Copyright © 2026 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+	"encoding/hex"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/hyperledger/firefly-common/pkg/log"
+)
+
+// DBSafeUTF8StringFromPtr returns a DB-safe UTF-8 string from a pointer, and true if the pointer
+// was non-nil. Strings containing invalid UTF-8 sequences or null bytes (which PostgreSQL rejects
+// in text columns even though null bytes are technically valid UTF-8) are hex-encoded instead,
+// with a warning logged.
+func DBSafeUTF8StringFromPtr(ctx context.Context, s *string) (string, bool) {
+	if s == nil {
+		return "", false
+	}
+	if !utf8.ValidString(*s) || strings.ContainsRune(*s, 0) {
+		hexString := hex.EncodeToString([]byte(*s))
+		log.L(ctx).Warnf("String contains invalid UTF-8 or null bytes - encoding as hex: %s", hexString)
+		return hexString, true
+	}
+	return *s, true
+}

--- a/pkg/utils/dbstring.go
+++ b/pkg/utils/dbstring.go
@@ -25,18 +25,18 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/log"
 )
 
-// DBSafeUTF8StringFromPtr returns a DB-safe UTF-8 string from a pointer, and true if the pointer
-// was non-nil. Strings containing invalid UTF-8 sequences or null bytes (which PostgreSQL rejects
-// in text columns even though null bytes are technically valid UTF-8) are hex-encoded instead,
-// with a warning logged.
-func DBSafeUTF8StringFromPtr(ctx context.Context, s *string) (string, bool) {
+// DBSafeUTF8StringFromPtr returns a DB-safe UTF-8 string from a pointer.
+// Nil pointers return "". Strings containing invalid UTF-8 sequences or null
+// bytes (which PostgreSQL rejects in text columns even though null bytes are
+// technically valid UTF-8) are hex-encoded instead, with a warning logged.
+func DBSafeUTF8StringFromPtr(ctx context.Context, s *string) string {
 	if s == nil {
-		return "", false
+		return ""
 	}
 	if !utf8.ValidString(*s) || strings.ContainsRune(*s, 0) {
 		hexString := hex.EncodeToString([]byte(*s))
 		log.L(ctx).Warnf("String contains invalid UTF-8 or null bytes - encoding as hex: %s", hexString)
-		return hexString, true
+		return hexString
 	}
-	return *s, true
+	return *s
 }

--- a/pkg/utils/dbstring_test.go
+++ b/pkg/utils/dbstring_test.go
@@ -24,32 +24,20 @@ import (
 )
 
 func TestDBSafeUTF8StringFromPtrNil(t *testing.T) {
-	s, ok := DBSafeUTF8StringFromPtr(context.Background(), nil)
-	assert.False(t, ok)
-	assert.Equal(t, "", s)
+	assert.Equal(t, "", DBSafeUTF8StringFromPtr(context.Background(), nil))
 }
 
 func TestDBSafeUTF8StringFromPtrValid(t *testing.T) {
 	msg := "FF23021: EVM reverted: some normal error message"
-	s, ok := DBSafeUTF8StringFromPtr(context.Background(), &msg)
-	assert.True(t, ok)
-	assert.Equal(t, msg, s)
+	assert.Equal(t, msg, DBSafeUTF8StringFromPtr(context.Background(), &msg))
 }
 
 func TestDBSafeUTF8StringFromPtrInvalidUTF8(t *testing.T) {
-	// Simulate the actual revert scenario: readable text with embedded ABI-encoded Error(string)
-	// selector bytes (0x08, 0xc3, 0x79, 0xa0) and null byte padding, which is invalid UTF-8
 	msg := "[OCPE]404/98 - \x08\xc3\x79\xa0\x00\x00\x00[TMM]404/16e"
-	s, ok := DBSafeUTF8StringFromPtr(context.Background(), &msg)
-	assert.True(t, ok)
-	assert.Equal(t, "5b4f4350455d3430342f3938202d2008c379a00000005b544d4d5d3430342f313665", s)
+	assert.Equal(t, "5b4f4350455d3430342f3938202d2008c379a00000005b544d4d5d3430342f313665", DBSafeUTF8StringFromPtr(context.Background(), &msg))
 }
 
 func TestDBSafeUTF8StringFromPtrNullBytesInValidUTF8(t *testing.T) {
-	// Pure null bytes embedded in otherwise valid UTF-8 text.
-	// utf8.ValidString returns true for this, but PostgreSQL rejects 0x00 in text columns.
 	msg := "hello\x00world"
-	s, ok := DBSafeUTF8StringFromPtr(context.Background(), &msg)
-	assert.True(t, ok)
-	assert.Equal(t, "68656c6c6f00776f726c64", s)
+	assert.Equal(t, "68656c6c6f00776f726c64", DBSafeUTF8StringFromPtr(context.Background(), &msg))
 }

--- a/pkg/utils/dbstring_test.go
+++ b/pkg/utils/dbstring_test.go
@@ -1,0 +1,55 @@
+// Copyright © 2026 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDBSafeUTF8StringFromPtrNil(t *testing.T) {
+	s, ok := DBSafeUTF8StringFromPtr(context.Background(), nil)
+	assert.False(t, ok)
+	assert.Equal(t, "", s)
+}
+
+func TestDBSafeUTF8StringFromPtrValid(t *testing.T) {
+	msg := "FF23021: EVM reverted: some normal error message"
+	s, ok := DBSafeUTF8StringFromPtr(context.Background(), &msg)
+	assert.True(t, ok)
+	assert.Equal(t, msg, s)
+}
+
+func TestDBSafeUTF8StringFromPtrInvalidUTF8(t *testing.T) {
+	// Simulate the actual revert scenario: readable text with embedded ABI-encoded Error(string)
+	// selector bytes (0x08, 0xc3, 0x79, 0xa0) and null byte padding, which is invalid UTF-8
+	msg := "[OCPE]404/98 - \x08\xc3\x79\xa0\x00\x00\x00[TMM]404/16e"
+	s, ok := DBSafeUTF8StringFromPtr(context.Background(), &msg)
+	assert.True(t, ok)
+	assert.Equal(t, "5b4f4350455d3430342f3938202d2008c379a00000005b544d4d5d3430342f313665", s)
+}
+
+func TestDBSafeUTF8StringFromPtrNullBytesInValidUTF8(t *testing.T) {
+	// Pure null bytes embedded in otherwise valid UTF-8 text.
+	// utf8.ValidString returns true for this, but PostgreSQL rejects 0x00 in text columns.
+	msg := "hello\x00world"
+	s, ok := DBSafeUTF8StringFromPtr(context.Background(), &msg)
+	assert.True(t, ok)
+	assert.Equal(t, "68656c6c6f00776f726c64", s)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## Proposed changes

This PR cherrypicks in changes from https://github.com/hyperledger/firefly/pull/1716 into the Kaleido fork of firefly-core.

From that PR:

```
This change tests the error string before making an update to the operations table checking that it is a valid UTF-8 string and does not contain null bytes. The second check is required because UTF-8 considers a single null byte to be a valid string but Postgres does not.
```
Fixes #1717

<hr>

## Types of changes

<!-- to mark a point done, place an x in square brackets. eg [x]-->
<!-- - [x] done with this task-->
<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [x] Bug fix 
- [ ] New feature added
- [ ] Documentation Update 

<hr>

## Please make sure to follow these points 

<!-- to mark a point done, place an x in square brackets. eg [x]-->
<!-- - [x] done with this task-->
<!----Please delete options that are not relevant. And in order to tick the check box just but x inside them for example [x] like this----->

- [x] I have read the contributing guidelines.
- [x] I have performed a self-review of my own code or work.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generates no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] My changes have sufficient code coverage (unit, integration, e2e tests).

<hr>

## Screenshots (If Applicable)

<hr>


## Other Information

Any message for the reviewer or kick off the discussion by explaining why you considered this particular solution, any alternatives etc.
