### PR TITLE
build(docker): postgresql-client instead of full postgresql server + sqlite3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y \
   && apt-get install -y --no-install-recommends \
      ca-certificates \
-  && apt-get install -y --no-install-recommends sqlite3 postgresql \
+  && apt-get install -y --no-install-recommends postgresql-client \
   && rm -rf /var/lib/apt/lists/*
 WORKDIR /firefly
 RUN chgrp -R 0 /firefly/ \


### PR DESCRIPTION
## Summary

Replaces the `sqlite3` and `postgresql` apt packages in the final image with `postgresql-client`.

Nothing in FireFly executes external database binaries — the postgres and sqlite3 plugins use in-process `database/sql` drivers (`internal/database/postgres`, `internal/database/sqlite3`), and migrations run via golang-migrate as a library (`GetMigrationDriver`), never by shelling out. The `psql` client was originally added purely as a debugging utility (73a4ef7df, on Alpine as `postgresql-client`); the Ubuntu base-image migration translated it to `postgresql`, which on Ubuntu is the metapackage that pulls in the entire PostgreSQL server. The `sqlite3` CLI is likewise debug-only tooling, and the Kaleido platform always runs firefly-core against postgres.

Dropping the server package tree and sqlite3 shrinks the image and removes a recurring source of CVE scan findings, while keeping `psql` available for debugging.